### PR TITLE
Add H2 Database Configuration and Update application.properties

### DIFF
--- a/src/main/resources/application-h2.properties
+++ b/src/main/resources/application-h2.properties
@@ -1,0 +1,11 @@
+# Datasource configuration
+spring.datasource.url=jdbc:h2:mem:clinicwave-user-management
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# H2 console configuration
+spring.h2.console.enabled=true
+
+# JPA database platform configuration
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,12 @@
 spring.application.name=clinicwave-user-management-service
+
+# Server port
+server.port=8080
+
+# Active profile
+spring.profiles.active=h2
+
+# JPA DDL and SQL configuration
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
### Description:
This pull request introduces significant updates to the application's configuration, specifically related to the H2 database and application properties.

### Changes:
- **Title:** Added H2 Database Configuration
  **Description:** A new file `application-h2.properties` has been added. This file contains the configuration for the H2 database, including the datasource URL, driver class name, username, and password. It also enables the H2 console and sets the JPA database platform to H2.

- **Title:** Updated Application Properties
  **Description:** The existing file `application.properties` has been updated. The application name is already present. The server port is set to 8080. The active profile is set to 'h2', which means the application will use the H2 database configuration when running. The JPA DDL auto-configuration is set to 'create', which means the schema will be automatically created on startup. SQL statements are set to be displayed in the console, and they will be formatted for better readability.

### Purpose:
The purpose of this pull request is to enhance the application's configuration, making it more robust and easier to manage. The addition of the H2 database configuration allows for easier local development and testing, while the updates to the application properties provide more control over the application's behavior.