### PR TITLE
Add Docker Compose and application-docker.properties

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+    db:
+        container_name: clinicwave-user-management-postgres
+        image: postgres:latest
+        restart: always
+        environment:
+            POSTGRES_DB: clinicwave-user-management
+            POSTGRES_USER: root
+            POSTGRES_PASSWORD: root
+        volumes:
+            - ./data:/var/lib/postgresql/data
+        ports:
+            - 5432:5432

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -1,0 +1,8 @@
+# Datasource configuration
+spring.datasource.url=jdbc:postgresql://localhost:5432/clinicwave-user-management
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.username=root
+spring.datasource.password=root
+
+# JPA database platform configuration
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.application.name=clinicwave-user-management-service
 server.port=8080
 
 # Active profile
-spring.profiles.active=h2
+spring.profiles.active=docker
 
 # JPA DDL and SQL configuration
 spring.jpa.hibernate.ddl-auto=create


### PR DESCRIPTION
### Description:
This pull request introduces Docker support for the application, enabling it to use a PostgreSQL database running in a Docker container.

### Changes:
- **Title:** Added Docker Compose Configuration
  A new file `docker-compose.yml` has been added. This file defines a Docker Compose configuration for a PostgreSQL database service. The service is named 'db', uses the latest PostgreSQL image, and restarts automatically. The environment variables for the database name, user, and password are set. A volume is created to persist the database data, and the PostgreSQL service is exposed on port 5432.

- **Added:** Docker Application Properties
  A new file `application-docker.properties` is added. This file contains the configuration for connecting to the PostgreSQL database defined in the Docker Compose file. It includes the datasource URL, driver class name, username, and password. The JPA database platform is set to PostgreSQL.

- **Updated:** Application Properties
  The existing file `application.properties` is updated. The active profile is changed from 'h2' to 'docker', which means the application will use the Docker database configuration when running.

### Purpose:
The purpose of this pull request is to add Docker support to the application, allowing it to use a PostgreSQL database for data persistence. This change will make the application more flexible and easier to deploy in different environments.