### PR TITLE
Add JPA Auditing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>annotationProcessor</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/ClinicwaveUserManagementServiceApplication.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/ClinicwaveUserManagementServiceApplication.java
@@ -2,8 +2,10 @@ package com.clinicwave.clinicwaveusermanagementservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")
 public class ClinicwaveUserManagementServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/audit/Audit.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/audit/Audit.java
@@ -1,0 +1,62 @@
+package com.clinicwave.clinicwaveusermanagementservice.audit;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * This abstract class provides auditing capabilities for entities.
+ * It includes fields for tracking the creation and modification of entities.
+ * Entities that need to be audited can extend this class.
+ *
+ * @author aamir on 5/27/24
+ */
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+public abstract class Audit implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * The timestamp when the entity was created.
+   * This field is not updatable.
+   */
+  @CreatedDate
+  @Column(updatable = false, nullable = false)
+  private LocalDateTime createdAt;
+
+  /**
+   * The user who created the entity.
+   * This field is not updatable.
+   */
+  @CreatedBy
+  @Column(updatable = false, nullable = false, length = 20)
+  private String createdBy;
+
+  /**
+   * The timestamp when the entity was last updated.
+   */
+  @LastModifiedDate
+  @Column(insertable = false)
+  private LocalDateTime updatedAt;
+
+  /**
+   * The user who last updated the entity.
+   */
+  @LastModifiedBy
+  @Column(insertable = false, length = 20)
+  private String updatedBy;
+}

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/audit/AuditorAwareImpl.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/audit/AuditorAwareImpl.java
@@ -1,0 +1,29 @@
+package com.clinicwave.clinicwaveusermanagementservice.audit;
+
+import lombok.NonNull;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * This class provides the current auditor for auditing purposes.
+ * It implements the AuditorAware interface from Spring Data JPA.
+ *
+ * @author aamir on 5/27/24
+ */
+@Component(value = "auditorAwareImpl")
+public class AuditorAwareImpl implements AuditorAware<String> {
+  /**
+   * The getCurrentAuditor method returns the username of the current user.
+   * In this implementation, the username is hardcoded as "user".
+   * TODO: method should return the username of the currently authenticated user.
+   *
+   * @return the username of the current auditor
+   */
+  @Override
+  @NonNull
+  public Optional<String> getCurrentAuditor() {
+    return Optional.of("user");
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces JPA Auditing capabilities to the Clinicwave User Management Service. It includes the addition of a new `Audit` class, an `AuditorAwareImpl` class, and necessary modifications to the main application class and `pom.xml`.

### Changes:
- **Added Lombok Dependency:** A new dependency on the Lombok library has been added to the `pom.xml` file. Lombok is a Java library that automatically plugs into your editor and build tools, spicing up your Java. It can generate getters and setters for those object properties and can help to reduce the boilerplate code.
- **Enabled JPA Auditing:** The `ClinicwaveUserManagementServiceApplication.java` file has been modified to enable JPA auditing. The `@EnableJpaAuditing` annotation is used to enable JPA auditing in the application. The `auditorAwareRef` attribute is set to "auditorAwareImpl", which is the name of the bean that will provide the current auditor.
- **Added Audit Class:** A new `Audit.java` file has been added in the `com.clinicwave.clinicwaveusermanagementservice.audit` package. This file defines an abstract `Audit` class that provides auditing capabilities for entities. It includes fields for tracking the creation and modification of entities. Entities that need to be audited can extend this class.
- **Added AuditorAwareImpl Class:** A new `AuditorAwareImpl.java` file has been added in the `com.clinicwave.clinicwaveusermanagementservice.audit` package. This file defines a class that provides the current auditor for auditing purposes. It implements the `AuditorAware` interface from Spring Data JPA. The `getCurrentAuditor` method returns the username of the current user. In this implementation, the username is hardcoded as "user".

### Purpose:
The purpose of this pull request is to add auditing capabilities to the Clinicwave User Management Service. This will allow for better tracking and management of entity creation and modifications.