### PR TITLE
Add unit tests for domain classes in user management service

### DIFF
--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/ClinicWaveUserTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/ClinicWaveUserTest.java
@@ -1,0 +1,144 @@
+package com.clinicwave.clinicwaveusermanagementservice.domain;
+
+import com.clinicwave.clinicwaveusermanagementservice.enums.GenderEnum;
+import com.clinicwave.clinicwaveusermanagementservice.repository.ClinicWaveUserRepository;
+import com.clinicwave.clinicwaveusermanagementservice.repository.RoleRepository;
+import com.clinicwave.clinicwaveusermanagementservice.repository.UserTypeRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This class is a test class for the ClinicWaveUser entity.
+ * It uses JUnit 5 and Spring Boot's testing capabilities.
+ * It tests the basic CRUD operations for the ClinicWaveUser entity.
+ *
+ * @author aamir on 6/20/24
+ */
+@ActiveProfiles("h2")
+@SpringBootTest
+class ClinicWaveUserTest {
+  private final ClinicWaveUserRepository userRepository;
+  private final RoleRepository roleRepository;
+  private final UserTypeRepository userTypeRepository;
+  private ClinicWaveUser user;
+
+  /**
+   * Constructor for dependency injection.
+   *
+   * @param userRepository     The repository for ClinicWaveUser entities.
+   * @param roleRepository     The repository for Role entities.
+   * @param userTypeRepository The repository for UserType entities.
+   */
+  @Autowired
+  public ClinicWaveUserTest(ClinicWaveUserRepository userRepository, RoleRepository roleRepository, UserTypeRepository userTypeRepository) {
+    this.userRepository = userRepository;
+    this.roleRepository = roleRepository;
+    this.userTypeRepository = userTypeRepository;
+  }
+
+  /**
+   * Set up method that runs before each test.
+   * It initializes a new ClinicWaveUser entity.
+   */
+  @BeforeEach
+  void setUp() {
+    user = new ClinicWaveUser();
+    user.setFirstName("Test");
+    user.setLastName("User");
+    user.setMobileNumber("1234567890");
+    user.setUsername("testuser");
+    user.setEmail("testuser@example.com");
+    user.setDateOfBirth(LocalDate.of(1990, 1, 1));
+    user.setGender(GenderEnum.MALE);
+  }
+
+  /**
+   * Tear down method that runs after each test.
+   * It deletes all ClinicWaveUser entities from the repository.
+   */
+  @AfterEach
+  void tearDown() {
+    userRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("User ID should be set after saving to repository")
+  void userIdShouldBeSetAfterSavingToRepository() {
+    userRepository.save(user);
+    assertNotNull(user.getId());
+  }
+
+  @Test
+  @DisplayName("User ID should be set and retrieved correctly")
+  void userIdShouldBeSetAndRetrievedCorrectly() {
+    Long id = 1L;
+    user.setId(id);
+    assertEquals(id, user.getId());
+  }
+
+  @Test
+  @DisplayName("User should be saved and retrieved from repository")
+  void userShouldBeSavedAndRetrievedFromRepository() {
+    userRepository.save(user);
+    Optional<ClinicWaveUser> retrievedUser = userRepository.findById(user.getId());
+    assertTrue(retrievedUser.isPresent());
+    assertEquals(user.getId(), retrievedUser.get().getId());
+    assertEquals(user.getFirstName(), retrievedUser.get().getFirstName());
+    assertEquals(user.getLastName(), retrievedUser.get().getLastName());
+    assertEquals(user.getMobileNumber(), retrievedUser.get().getMobileNumber());
+    assertEquals(user.getUsername(), retrievedUser.get().getUsername());
+    assertEquals(user.getEmail(), retrievedUser.get().getEmail());
+    assertEquals(user.getDateOfBirth(), retrievedUser.get().getDateOfBirth());
+    assertEquals(user.getGender(), retrievedUser.get().getGender());
+  }
+
+  @Test
+  @DisplayName("User role and userType should be saved and retrieved correctly")
+  void userRoleAndUserTypeShouldBeSavedAndRetrievedCorrectly() {
+    Role role = new Role();
+    role.setRoleName("TEST_ROLE");
+    Role savedRole = roleRepository.save(role);
+
+    UserType userType = new UserType();
+    userType.setType("TEST_TYPE");
+    UserType savedUserType = userTypeRepository.save(userType);
+
+    user.setRole(savedRole);
+    user.setUserType(savedUserType);
+
+    userRepository.save(user);
+    Optional<ClinicWaveUser> retrievedUser = userRepository.findById(user.getId());
+    assertTrue(retrievedUser.isPresent());
+    assertEquals(user.getId(), retrievedUser.get().getId());
+    assertEquals(user.getRole().getRoleName(), retrievedUser.get().getRole().getRoleName());
+    assertEquals(user.getUserType().getType(), retrievedUser.get().getUserType().getType());
+  }
+
+  @Test
+  @DisplayName("User should be deleted from repository")
+  void userShouldBeDeletedFromRepository() {
+    userRepository.save(user);
+    userRepository.delete(user);
+    Optional<ClinicWaveUser> retrievedUser = userRepository.findById(user.getId());
+    assertFalse(retrievedUser.isPresent());
+  }
+
+  @Test
+  @DisplayName("Duplicate user should throw an exception")
+  void duplicateUserShouldThrowException() {
+    userRepository.save(user);
+    ClinicWaveUser duplicateUser = new ClinicWaveUser();
+    duplicateUser.setUsername("testuser");
+    assertThrows(Exception.class, () -> userRepository.save(duplicateUser));
+  }
+}

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/PermissionTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/PermissionTest.java
@@ -1,0 +1,109 @@
+package com.clinicwave.clinicwaveusermanagementservice.domain;
+
+import com.clinicwave.clinicwaveusermanagementservice.repository.PermissionRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This class is a test class for the Permission entity.
+ * It uses JUnit 5 and Spring Boot's testing capabilities.
+ * It tests the basic CRUD operations for the Permission entity.
+ *
+ * @author aamir on 6/8/24
+ */
+@ActiveProfiles("h2")
+@SpringBootTest
+class PermissionTest {
+  private Permission permission;
+  private final PermissionRepository permissionRepository;
+
+  /**
+   * Constructor for dependency injection.
+   *
+   * @param permissionRepository The repository for Permission entities.
+   */
+  @Autowired
+  public PermissionTest(PermissionRepository permissionRepository) {
+    this.permissionRepository = permissionRepository;
+  }
+
+  /**
+   * Set up method that runs before each test.
+   * It initializes a new Permission entity.
+   */
+  @BeforeEach
+  void setUp() {
+    permission = new Permission();
+    permission.setPermissionName("TEST_PERMISSION");
+  }
+
+  /**
+   * Tear down method that runs after each test.
+   * It deletes all Permission entities from the repository.
+   */
+  @AfterEach
+  void tearDown() {
+    permissionRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("Permission ID should be set after saving to repository")
+  void permissionIdShouldBeSetAfterSavingToRepository() {
+    permissionRepository.save(permission);
+    assertNotNull(permission.getId());
+  }
+
+  @Test
+  @DisplayName("Permission should be saved in the repository")
+  void permissionShouldBeSavedInRepository() {
+    permissionRepository.save(permission);
+    assertTrue(permissionRepository.findById(permission.getId()).isPresent());
+  }
+
+  @Test
+  @DisplayName("Permission should be saved and retrieved from repository")
+  void permissionShouldBeSavedAndRetrievedFromRepository() {
+    permissionRepository.save(permission);
+    Optional<Permission> retrievedPermission = permissionRepository.findById(permission.getId());
+    assertTrue(retrievedPermission.isPresent());
+    assertEquals(permission.getId(), retrievedPermission.get().getId());
+    assertEquals(permission.getPermissionName(), retrievedPermission.get().getPermissionName());
+  }
+
+  @Test
+  @DisplayName("Permission should be updated")
+  void permissionShouldBeUpdated() {
+    Permission savedPermission = permissionRepository.save(permission);
+    savedPermission.setPermissionName("UPDATED_PERMISSION");
+    Permission updatedPermission = permissionRepository.save(savedPermission);
+    assertNotNull(updatedPermission);
+    assertEquals("UPDATED_PERMISSION", updatedPermission.getPermissionName());
+  }
+
+  @Test
+  @DisplayName("Permission should be deleted from repository")
+  void permissionShouldBeDeletedFromRepository() {
+    permissionRepository.save(permission);
+    permissionRepository.delete(permission);
+    Optional<Permission> retrievedPermission = permissionRepository.findById(permission.getId());
+    assertFalse(retrievedPermission.isPresent());
+  }
+
+  @Test
+  @DisplayName("Duplicate permission should throw an exception")
+  void duplicatePermissionShouldThrowException() {
+    permissionRepository.save(permission);
+    Permission duplicatePermission = new Permission();
+    duplicatePermission.setPermissionName("TEST_PERMISSION");
+    assertThrows(Exception.class, () -> permissionRepository.save(duplicatePermission));
+  }
+}

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/RoleTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/RoleTest.java
@@ -1,0 +1,141 @@
+package com.clinicwave.clinicwaveusermanagementservice.domain;
+
+import com.clinicwave.clinicwaveusermanagementservice.repository.PermissionRepository;
+import com.clinicwave.clinicwaveusermanagementservice.repository.RoleRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This class is a test class for the Role entity.
+ * It uses JUnit 5 and Spring Boot's testing capabilities.
+ * It tests the basic CRUD operations for the Role entity.
+ *
+ * @author aamir on 6/8/24
+ */
+@ActiveProfiles("h2")
+@SpringBootTest
+class RoleTest {
+  private Role role;
+  private Permission permission;
+
+  private final RoleRepository roleRepository;
+  private final PermissionRepository permissionRepository;
+
+  /**
+   * Constructor for dependency injection.
+   *
+   * @param roleRepository       The repository for Role entities.
+   * @param permissionRepository The repository for Permission entities.
+   */
+  @Autowired
+  public RoleTest(RoleRepository roleRepository, PermissionRepository permissionRepository) {
+    this.roleRepository = roleRepository;
+    this.permissionRepository = permissionRepository;
+  }
+
+  /**
+   * Set up method that runs before each test.
+   * It initializes a new Role and Permission entity.
+   */
+  @BeforeEach
+  void setUp() {
+    role = new Role();
+    role.setRoleName("TEST_ROLE");
+
+    permission = new Permission();
+    permission.setPermissionName("TEST_PERMISSION");
+  }
+
+  /**
+   * Tear down method that runs after each test.
+   * It deletes all Role and Permission entities from the repository.
+   */
+  @AfterEach
+  void tearDown() {
+    roleRepository.deleteAll();
+    permissionRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("Role ID should be set after saving to repository")
+  void roleIdShouldBeSetAfterSavingToRepository() {
+    roleRepository.save(role);
+    assertNotNull(role.getId());
+  }
+
+  @Test
+  @DisplayName("Role ID should be set and retrieved correctly")
+  void roleIdShouldBeSetAndRetrievedCorrectly() {
+    Long id = 1L;
+    role.setId(id);
+    assertEquals(id, role.getId());
+  }
+
+  @Test
+  @DisplayName("Role should be saved and retrieved from repository")
+  void roleShouldBeSavedAndRetrievedFromRepository() {
+    roleRepository.save(role);
+    Optional<Role> retrievedRole = roleRepository.findById(role.getId());
+    assertTrue(retrievedRole.isPresent());
+    assertEquals(role.getId(), retrievedRole.get().getId());
+    assertEquals(role.getRoleName(), retrievedRole.get().getRoleName());
+  }
+
+  @Test
+  @DisplayName("Role should be saved and retrieved from repository with role permissions")
+  void roleShouldBeSavedAndRetrievedFromRepositoryWithRolePermissions() {
+    permissionRepository.save(permission);
+
+    RolePermission rolePermission = new RolePermission();
+    rolePermission.setRole(role);
+    rolePermission.setPermission(permission);
+
+    Set<RolePermission> rolePermissions = new HashSet<>();
+    rolePermissions.add(rolePermission);
+    role.setRolePermissionSet(rolePermissions);
+
+    Role savedRole = roleRepository.save(role);
+
+    Optional<Role> retrievedRole = roleRepository.findById(savedRole.getId());
+    assertTrue(retrievedRole.isPresent());
+    Role retrievedRoleValue = retrievedRole.get();
+
+    assertEquals(savedRole.getId(), retrievedRoleValue.getId());
+    assertEquals(savedRole.getRoleName(), retrievedRoleValue.getRoleName());
+
+    assertNotNull(retrievedRoleValue.getRolePermissionSet());
+    assertEquals(1, retrievedRoleValue.getRolePermissionSet().size());
+
+    RolePermission retrievedRolePermission = retrievedRoleValue.getRolePermissionSet().iterator().next();
+    assertEquals(permission.getPermissionName(), retrievedRolePermission.getPermission().getPermissionName());
+  }
+
+  @Test
+  @DisplayName("Role should be deleted from repository")
+  void roleShouldBeDeletedFromRepository() {
+    roleRepository.save(role);
+    roleRepository.delete(role);
+    Optional<Role> retrievedRole = roleRepository.findById(role.getId());
+    assertFalse(retrievedRole.isPresent());
+  }
+
+  @Test
+  @DisplayName("Duplicate role should throw an exception")
+  void duplicateRoleShouldThrowException() {
+    roleRepository.save(role);
+    Role duplicateRole = new Role();
+    duplicateRole.setRoleName("TEST_ROLE");
+    assertThrows(Exception.class, () -> roleRepository.save(duplicateRole));
+  }
+}

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/UserTypeTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/UserTypeTest.java
@@ -1,0 +1,100 @@
+package com.clinicwave.clinicwaveusermanagementservice.domain;
+
+import com.clinicwave.clinicwaveusermanagementservice.repository.UserTypeRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This class is a test class for the UserType entity.
+ * It uses JUnit 5 and Spring Boot's testing capabilities.
+ * It tests the basic CRUD operations for the UserType entity.
+ *
+ * @author aamir on 6/20/24
+ */
+@ActiveProfiles("h2")
+@SpringBootTest
+class UserTypeTest {
+  private final UserTypeRepository userTypeRepository;
+  private UserType userType;
+
+  /**
+   * Constructor for dependency injection.
+   *
+   * @param userTypeRepository The repository for UserType entities.
+   */
+  @Autowired
+  public UserTypeTest(UserTypeRepository userTypeRepository) {
+    this.userTypeRepository = userTypeRepository;
+  }
+
+  /**
+   * Set up method that runs before each test.
+   * It initializes a new UserType entity.
+   */
+  @BeforeEach
+  void setUp() {
+    userType = new UserType();
+    userType.setType("TEST_TYPE");
+  }
+
+  /**
+   * Tear down method that runs after each test.
+   * It deletes all UserType entities from the repository.
+   */
+  @AfterEach
+  void tearDown() {
+    userTypeRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("UserType ID should be set after saving to repository")
+  void userTypeIdShouldBeSetAfterSavingToRepository() {
+    userTypeRepository.save(userType);
+    assertNotNull(userType.getId());
+  }
+
+  @Test
+  @DisplayName("UserType ID should be set and retrieved correctly")
+  void userTypeIdShouldBeSetAndRetrievedCorrectly() {
+    Long id = 1L;
+    userType.setId(id);
+    assertEquals(id, userType.getId());
+  }
+
+  @Test
+  @DisplayName("UserType should be saved and retrieved from repository")
+  void userTypeShouldBeSavedAndRetrievedFromRepository() {
+    userTypeRepository.save(userType);
+    Optional<UserType> retrievedUserType = userTypeRepository.findById(userType.getId());
+    assertTrue(retrievedUserType.isPresent());
+    assertEquals(userType.getId(), retrievedUserType.get().getId());
+    assertEquals(userType.getType(), retrievedUserType.get().getType());
+  }
+
+  @Test
+  @DisplayName("UserType should be deleted from repository")
+  void userTypeShouldBeDeletedFromRepository() {
+    userTypeRepository.save(userType);
+    userTypeRepository.delete(userType);
+    Optional<UserType> retrievedUserType = userTypeRepository.findById(userType.getId());
+    assertFalse(retrievedUserType.isPresent());
+  }
+
+  @Test
+  @DisplayName("Duplicate UserType should throw an exception")
+  void duplicateUserTypeShouldThrowException() {
+    userTypeRepository.save(userType);
+    UserType duplicateUserType = new UserType();
+    duplicateUserType.setType("TEST_TYPE");
+    assertThrows(Exception.class, () -> userTypeRepository.save(duplicateUserType));
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces comprehensive unit tests for the domain classes in the user management service. It adds test classes for ClinicWaveUser, Permission, Role, and UserType entities, covering CRUD operations and edge cases.

### Changes:
- **ClinicWaveUserTest:** Added unit tests for ClinicWaveUser entity CRUD operations
- **PermissionTest:** Added unit tests for Permission entity CRUD operations
- **RoleTest:** Added unit tests for Role entity CRUD operations
- **UserTypeTest:** Added unit tests for UserType entity CRUD operations
- **Test Coverage:** Implemented test cases for saving, retrieving, updating, and deleting entities
- **Edge Cases:** Added tests for handling duplicate entries and verifying relationships between entities
- **Test Configuration:** Configured tests to use H2 in-memory database with `@ActiveProfiles("h2")`

### Purpose:
The purpose of this pull request is to enhance the reliability and maintainability of the user management service by:
1. Ensuring proper functionality of CRUD operations for all domain entities
2. Verifying the handling of edge cases such as duplicate entries
3. Confirming the correct implementation of relationships between entities
4. Providing a foundation for future development and refactoring with confidence in existing functionality
5. Improving overall code quality and adherence to best practices in testing