### PR TITLE
Add response record classes for API communication

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/ErrorResponseDto.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/ErrorResponseDto.java
@@ -1,0 +1,17 @@
+package com.clinicwave.clinicwaveusermanagementservice.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author aamir on 6/16/24
+ */
+public record ErrorResponseDto(
+        String apiPath,
+
+        Integer httpStatusCode,
+
+        String errorMessage,
+
+        LocalDateTime errorTimestamp
+) {
+}

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/ResponseDto.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/ResponseDto.java
@@ -1,0 +1,11 @@
+package com.clinicwave.clinicwaveusermanagementservice.dto;
+
+/**
+ * @author aamir on 6/16/24
+ */
+public record ResponseDto(
+        Integer httpStatusCode,
+
+        String message
+) {
+}


### PR DESCRIPTION
### Description:
This pull request introduces standardized response classes for API communication in the ClinicWave User Management Service. It adds two new record classes to enhance consistency and clarity in API responses.

### Changes:
- **ErrorResponseDto:** Added a record class for standardized error responses, including API path, HTTP status code, error message, and timestamp
- **ResponseDto:** Added a record class for general API responses, including HTTP status code and message
- **Java Records:** Utilized Java records for creating immutable, concise data transfer objects

### Purpose:
The purpose of this pull request is to:
1. Standardize the structure of API responses across the User Management Service
2. Improve error handling and reporting by providing detailed, consistent error information
3. Enhance code readability and maintainability through the use of Java records
4. Facilitate easier parsing and handling of API responses on the client side
5. Lay the groundwork for implementing a uniform API response strategy throughout the ClinicWave ecosystem