### PR TITLE
Add custom UniqueField validator for entity fields

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/validator/UniqueField.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/validator/UniqueField.java
@@ -1,0 +1,25 @@
+package com.clinicwave.clinicwaveusermanagementservice.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+/**
+ * @author aamir on 6/18/24
+ */
+@Documented
+@Constraint(validatedBy = UniqueFieldValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UniqueField {
+  String message() default "{com.clinicwave.clinicwaveusermanagementservice.validator.UniqueField.message}";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+
+  String fieldName();
+
+  Class<?> domainClass();
+}

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/validator/UniqueFieldValidator.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/validator/UniqueFieldValidator.java
@@ -1,0 +1,34 @@
+package com.clinicwave.clinicwaveusermanagementservice.validator;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author aamir on 6/18/24
+ */
+public class UniqueFieldValidator implements ConstraintValidator<UniqueField, Object> {
+  private final EntityManager entityManager;
+  private String fieldName;
+  private Class<?> domainClass;
+
+  @Autowired
+  public UniqueFieldValidator(EntityManager entityManager) {
+    this.entityManager = entityManager;
+  }
+
+  @Override
+  public void initialize(UniqueField constraintAnnotation) {
+    this.fieldName = constraintAnnotation.fieldName();
+    this.domainClass = constraintAnnotation.domainClass();
+  }
+
+  @Override
+  public boolean isValid(Object value, ConstraintValidatorContext context) {
+    Query query = entityManager.createQuery("SELECT 1 FROM " + domainClass.getName() + " WHERE " + fieldName + "=:value");
+    query.setParameter("value", value);
+    return query.getResultList().isEmpty();
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces a custom UniqueField validator for ensuring the uniqueness of entity fields within the User Management service. It includes a new annotation and its corresponding validator implementation to provide a flexible and reusable solution for enforcing uniqueness constraints.

### Changes:
- **UniqueField Annotation:** Added a custom annotation to mark fields that should be unique within an entity
- **UniqueFieldValidator:** Implemented a validator class to perform the actual uniqueness validation
- **Jakarta Persistence Integration:** Utilized Jakarta Persistence API for database querying in the validator
- **Flexible Configuration:** Configured the validator to work with any entity class and field name
- **Dependency Injection:** Utilized Spring's dependency injection to provide EntityManager to the validator

### Purpose:
The purpose of this pull request is to enhance data integrity and validation capabilities within the User Management service. By introducing a custom UniqueField validator, we aim to provide a more robust and declarative way of enforcing uniqueness constraints on entity fields. This approach allows for easier maintenance and reduces the risk of data inconsistencies caused by duplicate entries.

The validator's flexibility enables its use across various entities and fields, promoting code reuse and maintaining a consistent validation approach throughout the service. By leveraging Jakarta Persistence API, the solution remains database-agnostic, ensuring compatibility with different database systems.

Furthermore, this implementation aligns with best practices in software development by separating concerns and utilizing dependency injection. It provides a foundation for future enhancements in data validation and integrity checks, contributing to the overall quality and reliability of the User Management service.