### PR TITLE
Add mapper classes for domain entities and DTOs

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/ClinicWaveUserMapper.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/ClinicWaveUserMapper.java
@@ -1,0 +1,84 @@
+package com.clinicwave.clinicwaveusermanagementservice.mapper;
+
+import com.clinicwave.clinicwaveusermanagementservice.domain.ClinicWaveUser;
+import com.clinicwave.clinicwaveusermanagementservice.dto.ClinicWaveUserDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class is responsible for mapping between the ClinicWaveUser domain object and the ClinicWaveUserDto data transfer object.
+ * It uses the RoleMapper and UserTypeMapper to handle the mapping of nested objects.
+ * The class is annotated with @Component to allow Spring to handle its lifecycle.
+ *
+ * @author aamir on 6/18/24
+ */
+@Component
+public class ClinicWaveUserMapper {
+  private final RoleMapper roleMapper;
+  private final UserTypeMapper userTypeMapper;
+
+  /**
+   * Constructor for the ClinicWaveUserMapper class.
+   * It initializes the roleMapper and userTypeMapper with the provided mappers.
+   *
+   * @param roleMapper     the RoleMapper to be used for mapping Role objects
+   * @param userTypeMapper the UserTypeMapper to be used for mapping UserType objects
+   */
+  @Autowired
+  public ClinicWaveUserMapper(RoleMapper roleMapper, UserTypeMapper userTypeMapper) {
+    this.roleMapper = roleMapper;
+    this.userTypeMapper = userTypeMapper;
+  }
+
+  /**
+   * Converts a ClinicWaveUser domain object into a ClinicWaveUserDto data transfer object.
+   * It uses the RoleMapper and UserTypeMapper to convert the nested Role and UserType objects.
+   *
+   * @param clinicWaveUser the ClinicWaveUser object to be converted
+   * @return the converted ClinicWaveUserDto object
+   */
+  public ClinicWaveUserDto toDto(ClinicWaveUser clinicWaveUser) {
+    return new ClinicWaveUserDto(
+            clinicWaveUser.getId(),
+            clinicWaveUser.getFirstName(),
+            clinicWaveUser.getLastName(),
+            clinicWaveUser.getMobileNumber(),
+            clinicWaveUser.getUsername(),
+            clinicWaveUser.getEmail(),
+            clinicWaveUser.getDateOfBirth(),
+            clinicWaveUser.getGender(),
+            clinicWaveUser.getBio(),
+            clinicWaveUser.getStatus(),
+            clinicWaveUser.getRole() != null ?
+                    roleMapper.toDto(clinicWaveUser.getRole()) : null,
+            clinicWaveUser.getUserType() != null ?
+                    userTypeMapper.toDto(clinicWaveUser.getUserType()) : null
+    );
+  }
+
+  /**
+   * Converts a ClinicWaveUserDto data transfer object into a ClinicWaveUser domain object.
+   * It uses the RoleMapper and UserTypeMapper to convert the nested RoleDto and UserTypeDto objects.
+   *
+   * @param clinicWaveUserDto the ClinicWaveUserDto object to be converted
+   * @return the converted ClinicWaveUser object
+   */
+  public ClinicWaveUser toEntity(ClinicWaveUserDto clinicWaveUserDto) {
+    return new ClinicWaveUser(
+            clinicWaveUserDto.id(),
+            clinicWaveUserDto.firstName(),
+            clinicWaveUserDto.lastName(),
+            clinicWaveUserDto.mobileNumber(),
+            clinicWaveUserDto.username(),
+            clinicWaveUserDto.email(),
+            clinicWaveUserDto.dateOfBirth(),
+            clinicWaveUserDto.gender(),
+            clinicWaveUserDto.bio(),
+            clinicWaveUserDto.status(),
+            clinicWaveUserDto.role() != null ?
+                    roleMapper.toEntity(clinicWaveUserDto.role()) : null,
+            clinicWaveUserDto.userType() != null ?
+                    userTypeMapper.toEntity(clinicWaveUserDto.userType()) : null
+    );
+  }
+}

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/PermissionMapper.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/PermissionMapper.java
@@ -1,0 +1,40 @@
+package com.clinicwave.clinicwaveusermanagementservice.mapper;
+
+import com.clinicwave.clinicwaveusermanagementservice.domain.Permission;
+import com.clinicwave.clinicwaveusermanagementservice.dto.PermissionDto;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class is responsible for mapping between the Permission domain object and the PermissionDto data transfer object.
+ * The class is annotated with @Component to allow Spring to handle its lifecycle.
+ *
+ * @author aamir on 6/16/24
+ */
+@Component
+public class PermissionMapper {
+  /**
+   * Converts a Permission domain object into a PermissionDto data transfer object.
+   *
+   * @param permission the Permission object to be converted
+   * @return the converted PermissionDto object
+   */
+  public PermissionDto toDto(Permission permission) {
+    return new PermissionDto(
+            permission.getId(),
+            permission.getPermissionName()
+    );
+  }
+
+  /**
+   * Converts a PermissionDto data transfer object into a Permission domain object.
+   *
+   * @param permissionDto the PermissionDto object to be converted
+   * @return the converted Permission object
+   */
+  public Permission toEntity(PermissionDto permissionDto) {
+    return new Permission(
+            permissionDto.id(),
+            permissionDto.permissionName()
+    );
+  }
+}

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/RoleMapper.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/RoleMapper.java
@@ -1,0 +1,80 @@
+package com.clinicwave.clinicwaveusermanagementservice.mapper;
+
+import com.clinicwave.clinicwaveusermanagementservice.domain.Role;
+import com.clinicwave.clinicwaveusermanagementservice.domain.RolePermission;
+import com.clinicwave.clinicwaveusermanagementservice.dto.RoleDto;
+import com.clinicwave.clinicwaveusermanagementservice.dto.RolePermissionDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This class is responsible for mapping between the Role domain object and the RoleDto data transfer object.
+ * It uses the RolePermissionMapper to handle the mapping of nested RolePermission objects.
+ * The class is annotated with @Component to allow Spring to handle its lifecycle.
+ *
+ * @author aamir on 6/16/24
+ */
+@Component
+public class RoleMapper {
+  private final RolePermissionMapper rolePermissionMapper;
+
+  /**
+   * Constructor for the RoleMapper class.
+   * It initializes the rolePermissionMapper with the provided mapper.
+   *
+   * @param rolePermissionMapper the RolePermissionMapper to be used for mapping RolePermission objects
+   */
+  @Autowired
+  public RoleMapper(@Lazy RolePermissionMapper rolePermissionMapper) {
+    this.rolePermissionMapper = rolePermissionMapper;
+  }
+
+  /**
+   * Converts a Role domain object into a RoleDto data transfer object.
+   * It uses the RolePermissionMapper to convert the nested RolePermission objects.
+   *
+   * @param role the Role object to be converted
+   * @return the converted RoleDto object
+   */
+  public RoleDto toDto(Role role) {
+    Set<RolePermissionDto> rolePermissionDtoSet = role.getRolePermissionSet() != null ?
+            role.getRolePermissionSet().stream()
+                    .map(rolePermissionMapper::toDto)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet()) : null;
+
+    return new RoleDto(
+            role.getId(),
+            role.getRoleName(),
+            role.getRoleDescription(),
+            rolePermissionDtoSet
+    );
+  }
+
+  /**
+   * Converts a RoleDto data transfer object into a Role domain object.
+   * It uses the RolePermissionMapper to convert the nested RolePermissionDto objects.
+   *
+   * @param roleDto the RoleDto object to be converted
+   * @return the converted Role object
+   */
+  public Role toEntity(RoleDto roleDto) {
+    Set<RolePermission> rolePermissionSet = roleDto.rolePermissionSet() != null ?
+            roleDto.rolePermissionSet().stream()
+                    .map(rolePermissionMapper::toEntity)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet()) : null;
+
+    return new Role(
+            roleDto.id(),
+            roleDto.roleName(),
+            roleDto.roleDescription(),
+            rolePermissionSet
+    );
+  }
+}

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/RolePermissionMapper.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/RolePermissionMapper.java
@@ -1,0 +1,77 @@
+package com.clinicwave.clinicwaveusermanagementservice.mapper;
+
+import com.clinicwave.clinicwaveusermanagementservice.domain.Permission;
+import com.clinicwave.clinicwaveusermanagementservice.domain.Role;
+import com.clinicwave.clinicwaveusermanagementservice.domain.RolePermission;
+import com.clinicwave.clinicwaveusermanagementservice.dto.PermissionDto;
+import com.clinicwave.clinicwaveusermanagementservice.dto.RoleDto;
+import com.clinicwave.clinicwaveusermanagementservice.dto.RolePermissionDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class is responsible for mapping between the RolePermission domain object and the RolePermissionDto data transfer object.
+ * It uses the RoleMapper and PermissionMapper to handle the mapping of nested Role and Permission objects.
+ * The class is annotated with @Component to allow Spring to handle its lifecycle.
+ *
+ * @author aamir on 6/16/24
+ */
+@Component
+public class RolePermissionMapper {
+  private final RoleMapper roleMapper;
+  private final PermissionMapper permissionMapper;
+
+  /**
+   * Constructor for the RolePermissionMapper class.
+   * It initializes the roleMapper and permissionMapper with the provided mappers.
+   *
+   * @param roleMapper       the RoleMapper to be used for mapping Role objects
+   * @param permissionMapper the PermissionMapper to be used for mapping Permission objects
+   */
+  @Autowired
+  public RolePermissionMapper(@Lazy RoleMapper roleMapper, PermissionMapper permissionMapper) {
+    this.roleMapper = roleMapper;
+    this.permissionMapper = permissionMapper;
+  }
+
+  /**
+   * Converts a RolePermission domain object into a RolePermissionDto data transfer object.
+   * It uses the RoleMapper and PermissionMapper to convert the nested Role and Permission objects.
+   *
+   * @param rolePermission the RolePermission object to be converted
+   * @return the converted RolePermissionDto object
+   */
+  public RolePermissionDto toDto(RolePermission rolePermission) {
+    RoleDto roleDto = rolePermission.getRole() != null ?
+            roleMapper.toDto(rolePermission.getRole()) : null;
+    PermissionDto permissionDto = rolePermission.getPermission() != null ?
+            permissionMapper.toDto(rolePermission.getPermission()) : null;
+
+    return new RolePermissionDto(
+            rolePermission.getId(),
+            roleDto,
+            permissionDto
+    );
+  }
+
+  /**
+   * Converts a RolePermissionDto data transfer object into a RolePermission domain object.
+   * It uses the RoleMapper and PermissionMapper to convert the nested RoleDto and PermissionDto objects.
+   *
+   * @param rolePermissionDto the RolePermissionDto object to be converted
+   * @return the converted RolePermission object
+   */
+  public RolePermission toEntity(RolePermissionDto rolePermissionDto) {
+    Role role = rolePermissionDto.role() != null ?
+            roleMapper.toEntity(rolePermissionDto.role()) : null;
+    Permission permission = rolePermissionDto.permission() != null ?
+            permissionMapper.toEntity(rolePermissionDto.permission()) : null;
+
+    return new RolePermission(
+            rolePermissionDto.id(),
+            role,
+            permission
+    );
+  }
+}

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/UserTypeMapper.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/UserTypeMapper.java
@@ -1,0 +1,40 @@
+package com.clinicwave.clinicwaveusermanagementservice.mapper;
+
+import com.clinicwave.clinicwaveusermanagementservice.domain.UserType;
+import com.clinicwave.clinicwaveusermanagementservice.dto.UserTypeDto;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class is responsible for mapping between the UserType domain object and the UserTypeDto data transfer object.
+ * The class is annotated with @Component to allow Spring to handle its lifecycle.
+ *
+ * @author aamir on 6/16/24
+ */
+@Component
+public class UserTypeMapper {
+  /**
+   * Converts a UserType domain object into a UserTypeDto data transfer object.
+   *
+   * @param userType the UserType object to be converted
+   * @return the converted UserTypeDto object
+   */
+  public UserTypeDto toDto(UserType userType) {
+    return new UserTypeDto(
+            userType.getId(),
+            userType.getType()
+    );
+  }
+
+  /**
+   * Converts a UserTypeDto data transfer object into a UserType domain object.
+   *
+   * @param userTypeDto the UserTypeDto object to be converted
+   * @return the converted UserType object
+   */
+  public UserType toEntity(UserTypeDto userTypeDto) {
+    return new UserType(
+            userTypeDto.id(),
+            userTypeDto.type()
+    );
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces new mapper classes for the `ClinicWaveUser`, `Permission`, `Role`, `RolePermission`, and `UserType` entities in the `clinicwave-user-management-service` project.

### Changes:
- Added Mapper Classes for Entities
  - Added `ClinicWaveUserMapper` for mapping between `ClinicWaveUser` entity and DTO.
  - Added `PermissionMapper` for mapping between `Permission` entity and DTO.
  - Added `RoleMapper` for mapping between `Role` entity and DTO.
  - Added `RolePermissionMapper` for mapping between `RolePermission` entity and DTO.
  - Added `UserTypeMapper` for mapping between `UserType` entity and DTO.
  - Implemented bidirectional mapping (toDto and toEntity) methods in each mapper class.
  - Used Spring's dependency injection to manage mapper dependencies.
  - Added comprehensive JavaDoc comments for all mapper classes and methods.

### Purpose:
The purpose of this pull request is to improve the code maintainability and readability by separating the mapping logic into dedicated mapper classes and providing clear and concise documentation for each class and method.