### PR TITLE
Add Repository Interfaces for ClinicWaveUser, Permission, Role, and UserType Entities

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/repository/ClinicWaveUserRepository.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/repository/ClinicWaveUserRepository.java
@@ -1,0 +1,13 @@
+package com.clinicwave.clinicwaveusermanagementservice.repository;
+
+import com.clinicwave.clinicwaveusermanagementservice.domain.ClinicWaveUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * This interface extends JpaRepository and provides CRUD operations for ClinicWaveUser entity.
+ * JpaRepository is a JPA specific extension of Repository which provides JPA related methods such as flushing the persistence context and deleting records in a batch.
+ *
+ * @author aamir on 6/8/24
+ */
+public interface ClinicWaveUserRepository extends JpaRepository<ClinicWaveUser, Long> {
+}

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/repository/PermissionRepository.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/repository/PermissionRepository.java
@@ -1,0 +1,13 @@
+package com.clinicwave.clinicwaveusermanagementservice.repository;
+
+import com.clinicwave.clinicwaveusermanagementservice.domain.Permission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * This interface extends JpaRepository and provides CRUD operations for Permission entity.
+ * JpaRepository is a JPA specific extension of Repository which provides JPA related methods such as flushing the persistence context and deleting records in a batch.
+ *
+ * @author aamir on 6/8/24
+ */
+public interface PermissionRepository extends JpaRepository<Permission, Long> {
+}

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/repository/RoleRepository.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/repository/RoleRepository.java
@@ -1,0 +1,13 @@
+package com.clinicwave.clinicwaveusermanagementservice.repository;
+
+import com.clinicwave.clinicwaveusermanagementservice.domain.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * This interface extends JpaRepository and provides CRUD operations for Role entity.
+ * JpaRepository is a JPA specific extension of Repository which provides JPA related methods such as flushing the persistence context and deleting records in a batch.
+ *
+ * @author aamir on 6/8/24
+ */
+public interface RoleRepository extends JpaRepository<Role, Long> {
+}

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/repository/UserTypeRepository.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/repository/UserTypeRepository.java
@@ -1,0 +1,13 @@
+package com.clinicwave.clinicwaveusermanagementservice.repository;
+
+import com.clinicwave.clinicwaveusermanagementservice.domain.UserType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * This interface extends JpaRepository and provides CRUD operations for UserType entity.
+ * JpaRepository is a JPA specific extension of Repository which provides JPA related methods such as flushing the persistence context and deleting records in a batch.
+ *
+ * @author aamir on 6/8/24
+ */
+public interface UserTypeRepository extends JpaRepository<UserType, Long> {
+}


### PR DESCRIPTION
### Description:
This pull request introduces new repository interfaces for the `ClinicWaveUser`, `Permission`, `Role`, and `UserType` entities.

### Changes:
- **Added:** Repository Interfaces for Entities
  - Added `ClinicWaveUserRepository` interface for CRUD operations on `ClinicWaveUser` entity.
  - Added `PermissionRepository` interface for CRUD operations on `Permission` entity.
  - Added `RoleRepository` interface for CRUD operations on `Role` entity.
  - Added `UserTypeRepository` interface for CRUD operations on `UserType` entity.

### Purpose:
The purpose of this pull request is to set up the repository layer of the application by providing the necessary interfaces for performing CRUD operations on the `ClinicWaveUser`, `Permission`, `Role`, and `UserType` entities.