### PR TITLE
Remove unnecessary validation annotations from ClinicWaveUserDto

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/ClinicWaveUserDto.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/ClinicWaveUserDto.java
@@ -16,7 +16,6 @@ import java.time.LocalDate;
  * @author aamir on 6/16/24
  */
 public record ClinicWaveUserDto(
-        @NotNull(message = "User ID cannot be null")
         Long id,
 
         @NotBlank(message = "First name cannot be blank")
@@ -48,13 +47,10 @@ public record ClinicWaveUserDto(
 
         String bio,
 
-        @NotNull(message = "Status cannot be null")
         Boolean status,
 
-        @NotNull(message = "Role cannot be null")
         RoleDto role,
 
-        @NotNull(message = "User type cannot be null")
         UserTypeDto userType
 ) implements Serializable {
 }


### PR DESCRIPTION
### Description:
This pull request introduces several changes to the `ClinicWaveUserDto` class, specifically the removal of certain `@NotNull` validation annotations.

### Changes:
- **Removed `@NotNull` validation:** The `@NotNull` validation annotation was removed from the `id` field in `ClinicWaveUserDto`.
- **Removed `@NotNull` validation:** The `@NotNull` validation annotation was removed from the `status` field in `ClinicWaveUserDto`.
- **Removed `@NotNull` validation:** The `@NotNull` validation annotation was removed from the `role` field in `ClinicWaveUserDto`.
- **Removed `@NotNull` validation:** The `@NotNull` validation annotation was removed from the `userType` field in `ClinicWaveUserDto`.

### Purpose:
The purpose of this pull request is to simplify the `ClinicWaveUserDto` by removing unnecessary validation annotations. These fields can be `null` in certain scenarios, such as when creating a new user, and therefore should not be constrained by `@NotNull` validation. This change makes the DTO more flexible and prevents potential validation errors.