### PR TITLE
Add ResourceNotFoundException for handling resource not found scenarios

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/exception/ResourceNotFoundException.java
@@ -1,0 +1,25 @@
+package com.clinicwave.clinicwaveusermanagementservice.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * This class represents a custom exception that is thrown when a resource is not found in the system.
+ * It is annotated with @ResponseStatus to automatically return a HttpStatus.NOT_FOUND when thrown.
+ * The exception takes in resourceName, fieldName, and fieldValue as parameters to construct a detailed error message.
+ *
+ * @author aamir on 6/16/24
+ */
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Resource not found")
+public class ResourceNotFoundException extends RuntimeException {
+  /**
+   * Constructs a new ResourceNotFoundException with the specified detail message.
+   *
+   * @param resourceName the name of the resource that was not found
+   * @param fieldName    the name of the field that was searched for
+   * @param fieldValue   the value of the field that was searched for
+   */
+  public ResourceNotFoundException(String resourceName, String fieldName, Long fieldValue) {
+    super(String.format("%s with %s: %s not found", resourceName, fieldName, fieldValue));
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces a new `ResourceNotFoundException` class for handling scenarios where a resource is not found.

### Changes:
- **Added `ResourceNotFoundException` class:** This new exception class is annotated with `@ResponseStatus` to automatically return a `HttpStatus.NOT_FOUND` when thrown. It takes in `resourceName`, `fieldName`, and `fieldValue` as parameters to construct a detailed error message.

### Purpose:
The purpose of this pull request is to enhance the error handling mechanism of the application by introducing a custom exception for resource not found scenarios. This will provide more specific error messages to the client when a resource is not found in the system.