### PR TITLE
Add RoleMismatchException for handling role mismatches

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/exception/RoleMismatchException.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/exception/RoleMismatchException.java
@@ -1,0 +1,27 @@
+package com.clinicwave.clinicwaveusermanagementservice.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * This class represents a custom exception that is thrown when there is a mismatch between the user's role and the expected role.
+ * It is annotated with @ResponseStatus to automatically return a HttpStatus.BAD_REQUEST when thrown.
+ * The exception takes in `resourceName`, `fieldName`, and `fieldValue` as parameters to construct a detailed error message.
+ * The error message will indicate that the role with the specified ID does not match the user's roleId.
+ * For example, this may be thrown when attempting to modify a user's role with an incorrect role ID.
+ *
+ * @author aamir on 6/18/24
+ */
+@ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Role mismatch")
+public class RoleMismatchException extends RuntimeException {
+  /**
+   * Constructs a new RoleMismatchException with the specified detail message.
+   *
+   * @param resourceName the name of the resource where the role mismatch occurred
+   * @param fieldName    the name of the field that caused the role mismatch
+   * @param fieldValue   the value of the field that caused the role mismatch
+   */
+  public RoleMismatchException(String resourceName, String fieldName, Long fieldValue) {
+    super(String.format("%s with %s %s does not match user's roleId", resourceName, fieldName, fieldValue));
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces a new custom exception, `RoleMismatchException`, to handle scenarios where there's a mismatch between a user's role and an expected role in the ClinicWave User Management Service.

### Changes:
- **Exception Handling:** Added new `RoleMismatchException` class in the exception package
- **HTTP Response:** Implemented @ResponseStatus annotation to automatically return HTTP 400 Bad Request when the exception is thrown
- **Error Messaging:** Included a detailed constructor for creating informative error messages, using `resourceName`, `fieldName`, and `fieldValue` parameters

### Purpose:
The primary purpose of this pull request is to enhance the error handling capabilities of our user management service, specifically in scenarios involving role mismatches. By introducing the `RoleMismatchException`, we aim to provide more precise and informative feedback when operations fail due to role-related issues.

This improvement will significantly benefit both developers and API consumers. For developers, it will streamline the debugging process by offering clear, context-specific error messages. This will lead to faster issue resolution and improved code maintenance. For API consumers, the detailed error responses will enable quicker understanding and resolution of issues on their end, enhancing the overall user experience of our service.

Furthermore, this addition aligns with our goal of building a more robust and reliable system. By handling role mismatch scenarios more effectively, we're proactively addressing a potential source of confusion and errors in our user management workflows. This contributes to the overall stability and dependability of our service, which is crucial as we continue to scale and expand our user base.