### PR TITLE
Add @Valid to ClinicWaveUserDto and remove ID validation in UserTypeDto

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/ClinicWaveUserDto.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/ClinicWaveUserDto.java
@@ -3,6 +3,7 @@ package com.clinicwave.clinicwaveusermanagementservice.dto;
 import com.clinicwave.clinicwaveusermanagementservice.domain.ClinicWaveUser;
 import com.clinicwave.clinicwaveusermanagementservice.enums.GenderEnum;
 import com.clinicwave.clinicwaveusermanagementservice.validator.UniqueField;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 
 import java.io.Serializable;
@@ -49,6 +50,7 @@ public record ClinicWaveUserDto(
 
         Boolean status,
 
+        @Valid
         RoleDto role,
 
         UserTypeDto userType

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/UserTypeDto.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/UserTypeDto.java
@@ -15,7 +15,6 @@ import java.io.Serializable;
  * @author aamir on 6/16/24
  */
 public record UserTypeDto(
-        @NotNull(message = "User type ID cannot be null")
         Long id,
 
         @NotBlank(message = "User type cannot be blank")


### PR DESCRIPTION
### Description:
This pull request introduces enhancements to the validation process in our DTOs and aligns the ID field handling with our established practices. It focuses on improving the `ClinicWaveUserDto` and `UserTypeDto` classes to ensure more robust and consistent data validation throughout the user management service.

### Changes:
- **Nested Validation:** Added `@Valid` annotation to the `role` field in `ClinicWaveUserDto` to enable recursive validation of nested DTOs.
- **ID Validation Removal:** Removed `@NotNull` annotation from the `id` field in `UserTypeDto` to align with our approach of not validating auto-generated IDs at the DTO level.
- **Import Update:** Imported `jakarta.validation.Valid` in `ClinicWaveUserDto` to support the new annotation.

### Purpose:
The purpose of this pull request is to refine our DTO validation strategy and streamline our data transfer object designs. By introducing nested validation for the `role` field in `ClinicWaveUserDto`, we ensure that all aspects of the role, including its associated permissions, are properly validated when processing user data. This change promotes data integrity and helps catch potential issues earlier in the data flow.

Simultaneously, by removing the ID validation in `UserTypeDto`, we're adhering to the principle of not over-validating auto-generated fields, which can lead to unnecessary complications during object creation or updates. This adjustment simplifies our DTO usage and reduces potential conflicts in API interactions.

Overall, these changes contribute to a more robust, consistent, and maintainable validation framework within our user management service. They enhance data integrity, reduce the likelihood of validation-related bugs, and improve the overall reliability of our DTOs in representing and transferring user-related data.