### PR TITLE
Improve Null Safety in Mapper Classes

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/PermissionMapper.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/PermissionMapper.java
@@ -4,6 +4,8 @@ import com.clinicwave.clinicwaveusermanagementservice.domain.Permission;
 import com.clinicwave.clinicwaveusermanagementservice.dto.PermissionDto;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 /**
  * This class is responsible for mapping between the Permission domain object and the PermissionDto data transfer object.
  * The class is annotated with @Component to allow Spring to handle its lifecycle.
@@ -19,10 +21,9 @@ public class PermissionMapper {
    * @return the converted PermissionDto object
    */
   public PermissionDto toDto(Permission permission) {
-    return new PermissionDto(
-            permission.getId(),
-            permission.getPermissionName()
-    );
+    return Optional.ofNullable(permission)
+            .map(p -> new PermissionDto(p.getId(), p.getPermissionName()))
+            .orElse(null);
   }
 
   /**
@@ -32,9 +33,8 @@ public class PermissionMapper {
    * @return the converted Permission object
    */
   public Permission toEntity(PermissionDto permissionDto) {
-    return new Permission(
-            permissionDto.id(),
-            permissionDto.permissionName()
-    );
+    return Optional.ofNullable(permissionDto)
+            .map(dto -> new Permission(dto.id(), dto.permissionName()))
+            .orElse(null);
   }
 }

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/UserTypeMapper.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/UserTypeMapper.java
@@ -4,6 +4,8 @@ import com.clinicwave.clinicwaveusermanagementservice.domain.UserType;
 import com.clinicwave.clinicwaveusermanagementservice.dto.UserTypeDto;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 /**
  * This class is responsible for mapping between the UserType domain object and the UserTypeDto data transfer object.
  * The class is annotated with @Component to allow Spring to handle its lifecycle.
@@ -19,10 +21,9 @@ public class UserTypeMapper {
    * @return the converted UserTypeDto object
    */
   public UserTypeDto toDto(UserType userType) {
-    return new UserTypeDto(
-            userType.getId(),
-            userType.getType()
-    );
+    return Optional.ofNullable(userType)
+            .map(u -> new UserTypeDto(u.getId(), u.getType()))
+            .orElse(null);
   }
 
   /**
@@ -32,9 +33,8 @@ public class UserTypeMapper {
    * @return the converted UserType object
    */
   public UserType toEntity(UserTypeDto userTypeDto) {
-    return new UserType(
-            userTypeDto.id(),
-            userTypeDto.type()
-    );
+    return Optional.ofNullable(userTypeDto)
+            .map(dto -> new UserType(dto.id(), dto.type()))
+            .orElse(null);
   }
 }


### PR DESCRIPTION
### Description:
This pull request introduces null safety checks in the `PermissionMapper`, `RoleMapper`, and `UserTypeMapper` classes. The changes involve using `Optional.ofNullable` to prevent potential `NullPointerExceptions` when converting between domain objects and data transfer objects if any of the objects are null.

### Changes:
- Added null safety checks in `PermissionMapper` class
  - Both `toDto` and `toEntity` methods now use `Optional.ofNullable` to ensure null safety.

- Enhanced null safety in `RoleMapper` class
  - The `toDto` method now uses `Optional.ofNullable` for `getRolePermissionSet` and the `toEntity` method uses `Optional.ofNullable` for `permissionSet` to ensure null safety.

- Introduced null safety checks in `UserTypeMapper` class
  - Both `toDto` and `toEntity` methods now use `Optional.ofNullable` to ensure null safety.

### Purpose:
The purpose of this pull request is to improve the robustness of the code by adding null safety checks. This prevents potential `NullPointerExceptions` that could occur when converting between domain objects and data transfer objects if any of the objects are null. The changes follow modern Java practices and improve the readability and maintainability of the code.