### PR TITLE
Refactor entity relationships for ClinicWaveUser and RolePermission

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/domain/ClinicWaveUser.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/domain/ClinicWaveUser.java
@@ -58,9 +58,9 @@ public class ClinicWaveUser extends Audit implements Serializable {
 
   private Boolean status;
 
-  @OneToOne(cascade = CascadeType.ALL)
+  @ManyToOne
   private Role role;
 
-  @OneToOne(cascade = CascadeType.ALL)
+  @ManyToOne
   private UserType userType;
 }

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/domain/RolePermission.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/domain/RolePermission.java
@@ -43,6 +43,6 @@ public class RolePermission extends Audit implements Serializable {
    * This field represents the associated Permission object.
    * It is annotated with @ManyToOne to establish a many-to-one relationship with the Permission entity.
    */
-  @ManyToOne(cascade = CascadeType.ALL)
+  @ManyToOne
   private Permission permission;
 }


### PR DESCRIPTION
### Description:
This pull request introduces significant changes to the entity relationships in the ClinicWave user management service, along with corresponding updates to the test suite. The modifications aim to enhance the flexibility and efficiency of data management within the system.

### Changes:
- **Entity Relationships:** Changed `ClinicWaveUser` entity relationships from `@OneToOne` to `@ManyToOne` for `Role` and `UserType`
- **Cascade Operations:** Removed `CascadeType.ALL` from `ClinicWaveUser` and `RolePermission` entity relationships
- **Test Suite:** Updated `ClinicWaveUserTest` to include testing for `Role`, `Permission`, and `UserType` entities
- **Test Infrastructure:** Added new repositories for `Role`, `Permission`, and `UserType` in the test class

### Purpose:
The purpose of this pull request is to improve the overall architecture of the user management service by implementing more appropriate entity relationships. By transitioning from one-to-one to many-to-one relationships for roles and user types, we allow multiple users to share the same role or user type, which better reflects real-world scenarios and improves database efficiency. The removal of cascade operations provides finer control over entity persistence, preventing unintended side effects during data operations.

Furthermore, the enhancements to the test suite ensure that these architectural changes are thoroughly validated. The expanded tests now cover the new relationship structure, verifying the correct saving and retrieval of associated entities. This not only confirms the integrity of our data model modifications but also strengthens our overall testing strategy, contributing to the long-term maintainability and reliability of the system.