### PR TITLE
Refactor RoleTest to include role description and role permissions

### DIFF
--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/RoleTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/RoleTest.java
@@ -52,6 +52,7 @@ class RoleTest {
   void setUp() {
     role = new Role();
     role.setRoleName("TEST_ROLE");
+    role.setRoleDescription("TEST_ROLE_DESCRIPTION");
 
     permission = new Permission();
     permission.setPermissionName("TEST_PERMISSION");
@@ -90,29 +91,30 @@ class RoleTest {
     assertTrue(retrievedRole.isPresent());
     assertEquals(role.getId(), retrievedRole.get().getId());
     assertEquals(role.getRoleName(), retrievedRole.get().getRoleName());
+    assertEquals(role.getRoleDescription(), retrievedRole.get().getRoleDescription());
   }
 
   @Test
   @DisplayName("Role should be saved and retrieved from repository with role permissions")
   void roleShouldBeSavedAndRetrievedFromRepositoryWithRolePermissions() {
-    Role savedRole = roleRepository.save(role);
+    permissionRepository.save(permission);
 
     RolePermission rolePermission = new RolePermission();
-    rolePermission.setRole(savedRole);
+    rolePermission.setRole(role);
     rolePermission.setPermission(permission);
 
     Set<RolePermission> rolePermissions = new HashSet<>();
     rolePermissions.add(rolePermission);
-    savedRole.setRolePermissionSet(rolePermissions);
+    role.setRolePermissionSet(rolePermissions);
 
-    roleRepository.save(savedRole);
+    roleRepository.save(role);
 
-    Optional<Role> retrievedRole = roleRepository.findById(savedRole.getId());
+    Optional<Role> retrievedRole = roleRepository.findById(role.getId());
     assertTrue(retrievedRole.isPresent());
     Role retrievedRoleValue = retrievedRole.get();
 
-    assertEquals(savedRole.getId(), retrievedRoleValue.getId());
-    assertEquals(savedRole.getRoleName(), retrievedRoleValue.getRoleName());
+    assertEquals(role.getId(), retrievedRoleValue.getId());
+    assertEquals(role.getRoleName(), retrievedRoleValue.getRoleName());
 
     assertNotNull(retrievedRoleValue.getRolePermissionSet());
     assertEquals(1, retrievedRoleValue.getRolePermissionSet().size());


### PR DESCRIPTION
### Description:
This pull request introduces significant improvements to the `RoleTest` class in the `clinicwave-user-management-service` project. The changes focus on enhancing the testing of the `Role` entity, particularly its description and associated permissions.

### Changes:
- **Role Description:** Added setting of `roleDescription` in the `setUp` method for the `Role` entity.
- **Permission Saving:** Moved the saving of `Permission` entity to the `roleShouldBeSavedAndRetrievedFromRepositoryWithRolePermissions` test method.
- **RolePermission Update:** Updated the `RolePermission` to use the `Role` and `Permission` entities created in the `setUp` method.
- **Role Update:** Updated the `Role` entity to include the `RolePermission` before saving it to the repository.
- **Assertion Update:** Updated the assertions in the `roleShouldBeSavedAndRetrievedFromRepositoryWithRolePermissions` test method to use the `Role` entity from the `setUp` method.

### Purpose:
The purpose of this pull request is to enhance the robustness of the unit tests for the `Role` entity. By ensuring that the `Role` entity, including its description and associated permissions, is thoroughly tested, we can catch potential issues or regressions early in the development process. This contributes to the overall quality and reliability of the `clinicwave-user-management-service` project, making it more maintainable and resilient in the long run.