### PR TITLE
Remove UniqueField validation annotations in PermissionDto, RoleDto, and UserTypeDto

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/PermissionDto.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/PermissionDto.java
@@ -1,7 +1,5 @@
 package com.clinicwave.clinicwaveusermanagementservice.dto;
 
-import com.clinicwave.clinicwaveusermanagementservice.domain.Permission;
-import com.clinicwave.clinicwaveusermanagementservice.validator.UniqueField;
 import jakarta.validation.constraints.NotBlank;
 
 /**
@@ -15,7 +13,6 @@ public record PermissionDto(
         Long id,
 
         @NotBlank(message = "Permission name cannot be blank")
-        @UniqueField(fieldName = "permissionName", domainClass = Permission.class)
         String permissionName
 ) {
 }

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/RoleDto.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/RoleDto.java
@@ -1,7 +1,5 @@
 package com.clinicwave.clinicwaveusermanagementservice.dto;
 
-import com.clinicwave.clinicwaveusermanagementservice.domain.Role;
-import com.clinicwave.clinicwaveusermanagementservice.validator.UniqueField;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 
@@ -18,7 +16,6 @@ public record RoleDto(
         Long id,
 
         @NotBlank(message = "Role name cannot be blank")
-        @UniqueField(fieldName = "roleName", domainClass = Role.class)
         String roleName,
 
         String roleDescription,

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/UserTypeDto.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/UserTypeDto.java
@@ -1,7 +1,5 @@
 package com.clinicwave.clinicwaveusermanagementservice.dto;
 
-import com.clinicwave.clinicwaveusermanagementservice.domain.UserType;
-import com.clinicwave.clinicwaveusermanagementservice.validator.UniqueField;
 import jakarta.validation.constraints.NotBlank;
 
 import java.io.Serializable;
@@ -17,7 +15,6 @@ public record UserTypeDto(
         Long id,
 
         @NotBlank(message = "User type cannot be blank")
-        @UniqueField(fieldName = "type", domainClass = UserType.class)
         String type
 ) implements Serializable {
 }


### PR DESCRIPTION
### Description:
This pull request introduces a cleanup in the `PermissionDto`, `RoleDto`, and `UserTypeDto` classes in the `clinicwave-user-management-service` project. The changes focus on removing unnecessary imports and annotations in these DTO classes.

### Changes:
- **PermissionDto Cleanup:** Removed the unused import of the `Permission` domain class and the `@UniqueField` annotation from the `permissionName` field.
- **RoleDto Cleanup:** Removed the unused import of the `Role` domain class and the `@UniqueField` annotation from the `roleName` field.
- **UserTypeDto Cleanup:** Removed the unused import of the `UserType` domain class and the `@UniqueField` annotation from the `type` field.

### Purpose:
The purpose of this pull request is to improve the readability and maintainability of the codebase by removing unnecessary imports and annotations in the DTO classes. By ensuring that the DTO classes only contain the necessary information for data transfer, we adhere to the principle of separation of concerns. This contributes to the overall quality and reliability of the `clinicwave-user-management-service` project, making it more maintainable and resilient in the long run.