### PR TITLE
Add UserStatusEnum and update ClinicWaveUser and ClinicWaveUserDto

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/domain/ClinicWaveUser.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/domain/ClinicWaveUser.java
@@ -2,6 +2,7 @@ package com.clinicwave.clinicwaveusermanagementservice.domain;
 
 import com.clinicwave.clinicwaveusermanagementservice.audit.Audit;
 import com.clinicwave.clinicwaveusermanagementservice.enums.GenderEnum;
+import com.clinicwave.clinicwaveusermanagementservice.enums.UserStatusEnum;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -56,7 +57,9 @@ public class ClinicWaveUser extends Audit implements Serializable {
 
   private String bio;
 
-  private Boolean status;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private UserStatusEnum status;
 
   @ManyToOne
   private Role role;

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/ClinicWaveUserDto.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/ClinicWaveUserDto.java
@@ -2,6 +2,7 @@ package com.clinicwave.clinicwaveusermanagementservice.dto;
 
 import com.clinicwave.clinicwaveusermanagementservice.domain.ClinicWaveUser;
 import com.clinicwave.clinicwaveusermanagementservice.enums.GenderEnum;
+import com.clinicwave.clinicwaveusermanagementservice.enums.UserStatusEnum;
 import com.clinicwave.clinicwaveusermanagementservice.validator.UniqueField;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
@@ -48,7 +49,7 @@ public record ClinicWaveUserDto(
 
         String bio,
 
-        Boolean status,
+        UserStatusEnum status,
 
         @Valid
         RoleDto role,

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/enums/UserStatusEnum.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/enums/UserStatusEnum.java
@@ -1,0 +1,14 @@
+package com.clinicwave.clinicwaveusermanagementservice.enums;
+
+/**
+ * An enum representing the status of a user in the system.
+ * It includes various statuses such as ACTIVE, INACTIVE, PENDING, and SUSPENDED.
+ *
+ * @author aamir on 6/29/24
+ */
+public enum UserStatusEnum {
+  ACTIVE,
+  INACTIVE,
+  PENDING,
+  SUSPENDED
+}


### PR DESCRIPTION
### Description:
This pull request introduces a new enumeration `UserStatusEnum` and updates the `ClinicWaveUser` and `ClinicWaveUserDto` classes in the `clinicwave-user-management-service` project. The changes focus on enhancing the representation of a user's status in the system.

### Changes:
- **UserStatusEnum Addition:** Added `UserStatusEnum` with various statuses such as ACTIVE, INACTIVE, PENDING, and SUSPENDED.
- **ClinicWaveUser Update:** Updated `ClinicWaveUser` domain class to replace the `status` field of type `Boolean` with `UserStatusEnum`.
- **ClinicWaveUserDto Update:** Updated `ClinicWaveUserDto` data transfer object to replace the `status` field of type `Boolean` with `UserStatusEnum`.

### Purpose:
The purpose of this pull request is to improve the expressiveness and clarity of the code by enhancing the representation of a user's status in the system. By introducing the `UserStatusEnum`, we can now represent various statuses such as ACTIVE, INACTIVE, PENDING, and SUSPENDED. This provides more information about the user's state in the system, contributing to the overall quality and reliability of the `clinicwave-user-management-service` project.