### PR TITLE
Refactor ClinicWaveUserMapper to remove role and user type mapping and add corresponding tests

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/ClinicWaveUserMapper.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/ClinicWaveUserMapper.java
@@ -2,44 +2,25 @@ package com.clinicwave.clinicwaveusermanagementservice.mapper;
 
 import com.clinicwave.clinicwaveusermanagementservice.domain.ClinicWaveUser;
 import com.clinicwave.clinicwaveusermanagementservice.dto.ClinicWaveUserDto;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
 
 /**
  * This class is responsible for mapping between the ClinicWaveUser domain object and the ClinicWaveUserDto data transfer object.
- * It uses the RoleMapper and UserTypeMapper to handle the mapping of nested objects.
  * The class is annotated with @Component to allow Spring to handle its lifecycle.
  *
  * @author aamir on 6/18/24
  */
 @Component
 public class ClinicWaveUserMapper {
-  private final RoleMapper roleMapper;
-  private final UserTypeMapper userTypeMapper;
-
-  /**
-   * Constructor for the ClinicWaveUserMapper class.
-   * It initializes the roleMapper and userTypeMapper with the provided mappers.
-   *
-   * @param roleMapper     the RoleMapper to be used for mapping Role objects
-   * @param userTypeMapper the UserTypeMapper to be used for mapping UserType objects
-   */
-  @Autowired
-  public ClinicWaveUserMapper(RoleMapper roleMapper, UserTypeMapper userTypeMapper) {
-    this.roleMapper = roleMapper;
-    this.userTypeMapper = userTypeMapper;
-  }
-
   /**
    * Converts a ClinicWaveUser domain object into a ClinicWaveUserDto data transfer object.
-   * It uses the RoleMapper and UserTypeMapper to convert the nested Role and UserType objects.
    *
    * @param clinicWaveUser the ClinicWaveUser object to be converted
    * @return the converted ClinicWaveUserDto object
    */
   public ClinicWaveUserDto toDto(ClinicWaveUser clinicWaveUser) {
+    if (clinicWaveUser == null) return null;
+
     return new ClinicWaveUserDto(
             clinicWaveUser.getId(),
             clinicWaveUser.getFirstName(),
@@ -49,38 +30,29 @@ public class ClinicWaveUserMapper {
             clinicWaveUser.getEmail(),
             clinicWaveUser.getDateOfBirth(),
             clinicWaveUser.getGender(),
-            clinicWaveUser.getBio(),
-            clinicWaveUser.getStatus(),
-            Optional.ofNullable(clinicWaveUser.getRole())
-                    .map(roleMapper::toDto).orElse(null),
-            Optional.ofNullable(clinicWaveUser.getUserType())
-                    .map(userTypeMapper::toDto).orElse(null)
+            clinicWaveUser.getBio()
     );
   }
 
   /**
    * Converts a ClinicWaveUserDto data transfer object into a ClinicWaveUser domain object.
-   * It uses the RoleMapper and UserTypeMapper to convert the nested RoleDto and UserTypeDto objects.
    *
    * @param clinicWaveUserDto the ClinicWaveUserDto object to be converted
    * @return the converted ClinicWaveUser object
    */
   public ClinicWaveUser toEntity(ClinicWaveUserDto clinicWaveUserDto) {
-    return new ClinicWaveUser(
-            clinicWaveUserDto.id(),
-            clinicWaveUserDto.firstName(),
-            clinicWaveUserDto.lastName(),
-            clinicWaveUserDto.mobileNumber(),
-            clinicWaveUserDto.username(),
-            clinicWaveUserDto.email(),
-            clinicWaveUserDto.dateOfBirth(),
-            clinicWaveUserDto.gender(),
-            clinicWaveUserDto.bio(),
-            clinicWaveUserDto.status(),
-            Optional.ofNullable(clinicWaveUserDto.role())
-                    .map(roleMapper::toEntity).orElse(null),
-            Optional.ofNullable(clinicWaveUserDto.userType())
-                    .map(userTypeMapper::toEntity).orElse(null)
-    );
+    if (clinicWaveUserDto == null) return null;
+
+    ClinicWaveUser clinicWaveUser = new ClinicWaveUser();
+    clinicWaveUser.setId(clinicWaveUserDto.id());
+    clinicWaveUser.setFirstName(clinicWaveUserDto.firstName());
+    clinicWaveUser.setLastName(clinicWaveUserDto.lastName());
+    clinicWaveUser.setMobileNumber(clinicWaveUserDto.mobileNumber());
+    clinicWaveUser.setUsername(clinicWaveUserDto.username());
+    clinicWaveUser.setEmail(clinicWaveUserDto.email());
+    clinicWaveUser.setDateOfBirth(clinicWaveUserDto.dateOfBirth());
+    clinicWaveUser.setGender(clinicWaveUserDto.gender());
+    clinicWaveUser.setBio(clinicWaveUserDto.bio());
+    return clinicWaveUser;
   }
 }

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/mapper/ClinicWaveUserMapperTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/mapper/ClinicWaveUserMapperTest.java
@@ -1,0 +1,131 @@
+package com.clinicwave.clinicwaveusermanagementservice.mapper;
+
+import com.clinicwave.clinicwaveusermanagementservice.domain.ClinicWaveUser;
+import com.clinicwave.clinicwaveusermanagementservice.dto.ClinicWaveUserDto;
+import com.clinicwave.clinicwaveusermanagementservice.enums.GenderEnum;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class for {@link ClinicWaveUserMapper}.
+ * It tests the mapping between {@link ClinicWaveUser} and {@link ClinicWaveUserDto}.
+ *
+ * @author aamir on 6/19/24
+ */
+@ActiveProfiles("h2")
+@SpringBootTest
+class ClinicWaveUserMapperTest {
+  private final ClinicWaveUserMapper clinicWaveUserMapper;
+
+  private ClinicWaveUser clinicWaveUser;
+  private ClinicWaveUserDto clinicWaveUserDto;
+
+  /**
+   * Constructor for the test class, initializes the mapper.
+   *
+   * @param clinicWaveUserMapper the mapper to be tested
+   */
+  @Autowired
+  public ClinicWaveUserMapperTest(ClinicWaveUserMapper clinicWaveUserMapper) {
+    this.clinicWaveUserMapper = clinicWaveUserMapper;
+  }
+
+  /**
+   * Sets up the test data before each test.
+   */
+  @BeforeEach
+  void setUp() {
+    clinicWaveUser = new ClinicWaveUser();
+    clinicWaveUser.setId(1L);
+    clinicWaveUser.setFirstName("John");
+    clinicWaveUser.setLastName("Doe");
+    clinicWaveUser.setMobileNumber("1234567890");
+    clinicWaveUser.setUsername("johndoe");
+    clinicWaveUser.setEmail("john.doe@example.com");
+    clinicWaveUser.setDateOfBirth(LocalDate.of(1990, 1, 1));
+    clinicWaveUser.setGender(GenderEnum.MALE);
+    clinicWaveUser.setBio("Bio");
+
+    clinicWaveUserDto = new ClinicWaveUserDto(
+            1L,
+            "John",
+            "Doe",
+            "1234567890",
+            "johndoe",
+            "john.doe@example.com",
+            LocalDate.of(1990, 1, 1),
+            GenderEnum.MALE,
+            "Bio"
+    );
+  }
+
+  @Test
+  @DisplayName("Should map ClinicWaveUser to ClinicWaveUserDto")
+  void testToDto() {
+    ClinicWaveUserDto result = clinicWaveUserMapper.toDto(clinicWaveUser);
+
+    assertNotNull(result);
+    assertEquals(clinicWaveUserDto.id(), result.id());
+    assertEquals(clinicWaveUserDto.firstName(), result.firstName());
+    assertEquals(clinicWaveUserDto.lastName(), result.lastName());
+    assertEquals(clinicWaveUserDto.mobileNumber(), result.mobileNumber());
+    assertEquals(clinicWaveUserDto.username(), result.username());
+    assertEquals(clinicWaveUserDto.email(), result.email());
+    assertEquals(clinicWaveUserDto.dateOfBirth(), result.dateOfBirth());
+    assertEquals(clinicWaveUserDto.gender(), result.gender());
+    assertEquals(clinicWaveUserDto.bio(), result.bio());
+  }
+
+  @Test
+  @DisplayName("Should map ClinicWaveUserDto to ClinicWaveUser")
+  void testToEntity() {
+    ClinicWaveUser result = clinicWaveUserMapper.toEntity(clinicWaveUserDto);
+
+    assertNotNull(result);
+    assertEquals(clinicWaveUser.getId(), result.getId());
+    assertEquals(clinicWaveUser.getFirstName(), result.getFirstName());
+    assertEquals(clinicWaveUser.getLastName(), result.getLastName());
+    assertEquals(clinicWaveUser.getMobileNumber(), result.getMobileNumber());
+    assertEquals(clinicWaveUser.getUsername(), result.getUsername());
+    assertEquals(clinicWaveUser.getEmail(), result.getEmail());
+    assertEquals(clinicWaveUser.getDateOfBirth(), result.getDateOfBirth());
+    assertEquals(clinicWaveUser.getGender(), result.getGender());
+    assertEquals(clinicWaveUser.getBio(), result.getBio());
+  }
+
+  @Test
+  @DisplayName("Should map ClinicWaveUser to ClinicWaveUserDto and back")
+  void shouldMapClinicWaveUserToClinicWaveUserDto() {
+    ClinicWaveUserDto intermediateDto = clinicWaveUserMapper.toDto(clinicWaveUser);
+    ClinicWaveUser roundTripUser = clinicWaveUserMapper.toEntity(intermediateDto);
+
+    assertNotNull(roundTripUser);
+    assertEquals(clinicWaveUser.getId(), roundTripUser.getId());
+    assertEquals(clinicWaveUser.getFirstName(), roundTripUser.getFirstName());
+    assertEquals(clinicWaveUser.getLastName(), roundTripUser.getLastName());
+    assertEquals(clinicWaveUser.getMobileNumber(), roundTripUser.getMobileNumber());
+    assertEquals(clinicWaveUser.getUsername(), roundTripUser.getUsername());
+    assertEquals(clinicWaveUser.getEmail(), roundTripUser.getEmail());
+    assertEquals(clinicWaveUser.getDateOfBirth(), roundTripUser.getDateOfBirth());
+    assertEquals(clinicWaveUser.getGender(), roundTripUser.getGender());
+    assertEquals(clinicWaveUser.getBio(), roundTripUser.getBio());
+  }
+
+  @Test
+  @DisplayName("Should handle null values")
+  void shouldHandleNullValues() {
+    ClinicWaveUser nullUser = null;
+    ClinicWaveUserDto nullDto = null;
+
+    assertNull(clinicWaveUserMapper.toDto(nullUser));
+    assertNull(clinicWaveUserMapper.toEntity(nullDto));
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces a significant refactor of the `ClinicWaveUserMapper` and adds corresponding tests in the `clinicwave-user-management-service` project.

### Changes:
- **ClinicWaveUserMapper Refactor:** Removed dependencies on `RoleMapper` and `UserTypeMapper`, and simplified the `toDto` and `toEntity` methods to directly map between `ClinicWaveUser` and `ClinicWaveUserDto` without handling nested objects. Added null checks in these methods for robustness.
- **ClinicWaveUserMapperTest Addition:** Created a new test class `ClinicWaveUserMapperTest` to test the mapping between `ClinicWaveUser` and `ClinicWaveUserDto`.

### Purpose:
The purpose of this pull request is to simplify the `ClinicWaveUserMapper` by removing unnecessary dependencies and handling of nested objects. This makes the mapper easier to understand and maintain. The addition of the `ClinicWaveUserMapperTest` ensures that the mapper functions correctly, enhancing the reliability of the code. This contributes to the overall quality and maintainability of the `clinicwave-user-management-service` project.