### PR TITLE
Implement Enums for Role, Permission, and UserType Entities

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/domain/Permission.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/domain/Permission.java
@@ -1,6 +1,7 @@
 package com.clinicwave.clinicwaveusermanagementservice.domain;
 
 import com.clinicwave.clinicwaveusermanagementservice.audit.Audit;
+import com.clinicwave.clinicwaveusermanagementservice.enums.PermissionNameEnum;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -30,6 +31,7 @@ public class Permission extends Audit implements Serializable {
   @GeneratedValue(strategy = GenerationType.AUTO)
   private Long id;
 
+  @Enumerated(EnumType.STRING)
   @Column(nullable = false, unique = true)
-  private String permissionName;
+  private PermissionNameEnum permissionName;
 }

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/domain/Role.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/domain/Role.java
@@ -1,6 +1,7 @@
 package com.clinicwave.clinicwaveusermanagementservice.domain;
 
 import com.clinicwave.clinicwaveusermanagementservice.audit.Audit;
+import com.clinicwave.clinicwaveusermanagementservice.enums.RoleNameEnum;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -31,8 +32,10 @@ public class Role extends Audit implements Serializable {
   @GeneratedValue(strategy = GenerationType.AUTO)
   private Long id;
 
+  @Enumerated(EnumType.STRING)
   @Column(nullable = false, unique = true)
-  private String roleName;
+  private RoleNameEnum roleName;
+
   private String roleDescription;
 
   /**

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/domain/UserType.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/domain/UserType.java
@@ -1,6 +1,7 @@
 package com.clinicwave.clinicwaveusermanagementservice.domain;
 
 import com.clinicwave.clinicwaveusermanagementservice.audit.Audit;
+import com.clinicwave.clinicwaveusermanagementservice.enums.UserTypeEnum;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -30,6 +31,7 @@ public class UserType extends Audit implements Serializable {
   @GeneratedValue(strategy = GenerationType.AUTO)
   private Long id;
 
+  @Enumerated(EnumType.STRING)
   @Column(nullable = false, unique = true)
-  private String type;
+  private UserTypeEnum type;
 }

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/PermissionDto.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/PermissionDto.java
@@ -1,5 +1,6 @@
 package com.clinicwave.clinicwaveusermanagementservice.dto;
 
+import com.clinicwave.clinicwaveusermanagementservice.enums.PermissionNameEnum;
 import jakarta.validation.constraints.NotBlank;
 
 /**
@@ -13,6 +14,6 @@ public record PermissionDto(
         Long id,
 
         @NotBlank(message = "Permission name cannot be blank")
-        String permissionName
+        PermissionNameEnum permissionName
 ) {
 }

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/RoleDto.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/RoleDto.java
@@ -1,5 +1,6 @@
 package com.clinicwave.clinicwaveusermanagementservice.dto;
 
+import com.clinicwave.clinicwaveusermanagementservice.enums.RoleNameEnum;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 
@@ -16,7 +17,7 @@ public record RoleDto(
         Long id,
 
         @NotBlank(message = "Role name cannot be blank")
-        String roleName,
+        RoleNameEnum roleName,
 
         String roleDescription,
 

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/UserTypeDto.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/UserTypeDto.java
@@ -1,5 +1,6 @@
 package com.clinicwave.clinicwaveusermanagementservice.dto;
 
+import com.clinicwave.clinicwaveusermanagementservice.enums.UserTypeEnum;
 import jakarta.validation.constraints.NotBlank;
 
 import java.io.Serializable;
@@ -15,6 +16,6 @@ public record UserTypeDto(
         Long id,
 
         @NotBlank(message = "User type cannot be blank")
-        String type
+        UserTypeEnum type
 ) implements Serializable {
 }

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/enums/PermissionNameEnum.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/enums/PermissionNameEnum.java
@@ -1,0 +1,11 @@
+package com.clinicwave.clinicwaveusermanagementservice.enums;
+
+/**
+ * @author aamir on 6/30/24
+ */
+public enum PermissionNameEnum {
+  PERMISSION_READ,
+  PERMISSION_WRITE,
+  PERMISSION_DELETE,
+  PERMISSION_UPDATE
+}

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/enums/RoleNameEnum.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/enums/RoleNameEnum.java
@@ -1,0 +1,15 @@
+package com.clinicwave.clinicwaveusermanagementservice.enums;
+
+/**
+ * @author aamir on 6/30/24
+ */
+public enum RoleNameEnum {
+  ROLE_DEFAULT,
+  ROLE_ADMIN,
+  ROLE_USER,
+  ROLE_GUARDIAN,
+  ROLE_DOCTOR,
+  ROLE_NURSE,
+  ROLE_RECEPTIONIST,
+  ROLE_PATIENT
+}

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/enums/UserTypeEnum.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/enums/UserTypeEnum.java
@@ -1,0 +1,15 @@
+package com.clinicwave.clinicwaveusermanagementservice.enums;
+
+/**
+ * @author aamir on 6/30/24
+ */
+public enum UserTypeEnum {
+  USER_TYPE_DEFAULT,
+  USER_TYPE_ADMIN,
+  USER_TYPE_USER,
+  USER_TYPE_GUARDIAN,
+  USER_TYPE_DOCTOR,
+  USER_TYPE_NURSE,
+  USER_TYPE_RECEPTIONIST,
+  USER_TYPE_PATIENT
+}

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/ClinicWaveUserTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/ClinicWaveUserTest.java
@@ -1,6 +1,6 @@
 package com.clinicwave.clinicwaveusermanagementservice.domain;
 
-import com.clinicwave.clinicwaveusermanagementservice.enums.GenderEnum;
+import com.clinicwave.clinicwaveusermanagementservice.enums.*;
 import com.clinicwave.clinicwaveusermanagementservice.repository.ClinicWaveUserRepository;
 import com.clinicwave.clinicwaveusermanagementservice.repository.PermissionRepository;
 import com.clinicwave.clinicwaveusermanagementservice.repository.RoleRepository;
@@ -71,19 +71,20 @@ class ClinicWaveUserTest {
     user.setEmail("testuser@example.com");
     user.setDateOfBirth(LocalDate.of(1990, 1, 1));
     user.setGender(GenderEnum.MALE);
+    user.setStatus(UserStatusEnum.PENDING);
 
     role = new Role();
-    role.setRoleName("TEST_ROLE");
+    role.setRoleName(RoleNameEnum.ROLE_DEFAULT);
 
     permission = new Permission();
-    permission.setPermissionName("TEST_PERMISSION");
+    permission.setPermissionName(PermissionNameEnum.PERMISSION_READ);
 
     rolePermission = new RolePermission();
     rolePermission.setRole(role);
     rolePermission.setPermission(permission);
 
     userType = new UserType();
-    userType.setType("TEST_TYPE");
+    userType.setType(UserTypeEnum.USER_TYPE_DEFAULT);
   }
 
   /**
@@ -127,6 +128,7 @@ class ClinicWaveUserTest {
     assertEquals(user.getEmail(), retrievedUser.get().getEmail());
     assertEquals(user.getDateOfBirth(), retrievedUser.get().getDateOfBirth());
     assertEquals(user.getGender(), retrievedUser.get().getGender());
+    assertEquals(user.getStatus(), retrievedUser.get().getStatus());
   }
 
   @Test

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/PermissionTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/PermissionTest.java
@@ -1,5 +1,6 @@
 package com.clinicwave.clinicwaveusermanagementservice.domain;
 
+import com.clinicwave.clinicwaveusermanagementservice.enums.PermissionNameEnum;
 import com.clinicwave.clinicwaveusermanagementservice.repository.PermissionRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,7 +44,7 @@ class PermissionTest {
   @BeforeEach
   void setUp() {
     permission = new Permission();
-    permission.setPermissionName("TEST_PERMISSION");
+    permission.setPermissionName(PermissionNameEnum.PERMISSION_READ);
   }
 
   /**
@@ -83,10 +84,10 @@ class PermissionTest {
   @DisplayName("Permission should be updated")
   void permissionShouldBeUpdated() {
     Permission savedPermission = permissionRepository.save(permission);
-    savedPermission.setPermissionName("UPDATED_PERMISSION");
+    savedPermission.setPermissionName(PermissionNameEnum.PERMISSION_WRITE);
     Permission updatedPermission = permissionRepository.save(savedPermission);
     assertNotNull(updatedPermission);
-    assertEquals("UPDATED_PERMISSION", updatedPermission.getPermissionName());
+    assertEquals(PermissionNameEnum.PERMISSION_WRITE, updatedPermission.getPermissionName());
   }
 
   @Test
@@ -103,7 +104,7 @@ class PermissionTest {
   void duplicatePermissionShouldThrowException() {
     permissionRepository.save(permission);
     Permission duplicatePermission = new Permission();
-    duplicatePermission.setPermissionName("TEST_PERMISSION");
+    duplicatePermission.setPermissionName(PermissionNameEnum.PERMISSION_READ);
     assertThrows(Exception.class, () -> permissionRepository.save(duplicatePermission));
   }
 }

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/RoleTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/RoleTest.java
@@ -1,5 +1,7 @@
 package com.clinicwave.clinicwaveusermanagementservice.domain;
 
+import com.clinicwave.clinicwaveusermanagementservice.enums.PermissionNameEnum;
+import com.clinicwave.clinicwaveusermanagementservice.enums.RoleNameEnum;
 import com.clinicwave.clinicwaveusermanagementservice.repository.PermissionRepository;
 import com.clinicwave.clinicwaveusermanagementservice.repository.RoleRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -51,11 +53,11 @@ class RoleTest {
   @BeforeEach
   void setUp() {
     role = new Role();
-    role.setRoleName("TEST_ROLE");
+    role.setRoleName(RoleNameEnum.ROLE_DEFAULT);
     role.setRoleDescription("TEST_ROLE_DESCRIPTION");
 
     permission = new Permission();
-    permission.setPermissionName("TEST_PERMISSION");
+    permission.setPermissionName(PermissionNameEnum.PERMISSION_READ);
   }
 
   /**
@@ -137,7 +139,7 @@ class RoleTest {
   void duplicateRoleShouldThrowException() {
     roleRepository.save(role);
     Role duplicateRole = new Role();
-    duplicateRole.setRoleName("TEST_ROLE");
+    duplicateRole.setRoleName(RoleNameEnum.ROLE_DEFAULT);
     assertThrows(Exception.class, () -> roleRepository.save(duplicateRole));
   }
 }

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/UserTypeTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/UserTypeTest.java
@@ -1,5 +1,6 @@
 package com.clinicwave.clinicwaveusermanagementservice.domain;
 
+import com.clinicwave.clinicwaveusermanagementservice.enums.UserTypeEnum;
 import com.clinicwave.clinicwaveusermanagementservice.repository.UserTypeRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,7 +44,7 @@ class UserTypeTest {
   @BeforeEach
   void setUp() {
     userType = new UserType();
-    userType.setType("TEST_TYPE");
+    userType.setType(UserTypeEnum.USER_TYPE_DEFAULT);
   }
 
   /**
@@ -94,7 +95,7 @@ class UserTypeTest {
   void duplicateUserTypeShouldThrowException() {
     userTypeRepository.save(userType);
     UserType duplicateUserType = new UserType();
-    duplicateUserType.setType("TEST_TYPE");
+    duplicateUserType.setType(UserTypeEnum.USER_TYPE_DEFAULT);
     assertThrows(Exception.class, () -> userTypeRepository.save(duplicateUserType));
   }
 }


### PR DESCRIPTION
### Description:
This pull request introduces enums for Role, Permission, and UserType entities to improve type safety and code readability. It replaces string-based representations with strongly-typed enums for role names, permission names, and user types throughout the codebase.

### Changes:
- **Enums:** Added `RoleNameEnum`, `PermissionNameEnum`, and `UserTypeEnum` to represent possible values for role names, permission names, and user types respectively.
- **Entities:** Updated `Role`, `Permission`, and `UserType` entities to use the new enums instead of strings.
- **DTOs:** Modified `RoleDto`, `PermissionDto`, and `UserTypeDto` to incorporate the new enum types.
- **Tests:** Updated test classes `ClinicWaveUserTest`, `PermissionTest`, `RoleTest`, and `UserTypeTest` to utilize the new enum types.

### Purpose:
The purpose of this pull request is to enhance the overall code quality by introducing strongly-typed enums for role names, permission names, and user types. This change will significantly reduce the risk of errors caused by typos or invalid values, while simultaneously improving code readability and maintainability. By using enums, we ensure that only valid values can be assigned to these fields, which will lead to more robust and error-resistant code. Additionally, this change will make the codebase more self-documenting, as the possible values for these fields are now explicitly defined within the enum declarations.