### PR TITLE
Add Custom Error Messages to UniqueField Annotations in ClinicWaveUserDto

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/ClinicWaveUserDto.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/ClinicWaveUserDto.java
@@ -26,16 +26,28 @@ public record ClinicWaveUserDto(
 
         @NotBlank(message = "Mobile number cannot be blank")
         @Pattern(regexp = "^\\d{10}$", message = "Invalid mobile number format")
-        @UniqueField(fieldName = "mobileNumber", domainClass = ClinicWaveUser.class)
+        @UniqueField(
+                message = "Mobile number is already registered. Please use a different number",
+                fieldName = "mobileNumber",
+                domainClass = ClinicWaveUser.class
+        )
         String mobileNumber,
 
         @NotBlank(message = "Username cannot be blank")
-        @UniqueField(fieldName = "username", domainClass = ClinicWaveUser.class)
+        @UniqueField(
+                message = "username is already taken. Please choose a different username",
+                fieldName = "username",
+                domainClass = ClinicWaveUser.class
+        )
         String username,
 
         @NotBlank(message = "Email cannot be blank")
         @Email(message = "Invalid email format")
-        @UniqueField(fieldName = "email", domainClass = ClinicWaveUser.class)
+        @UniqueField(
+                message = "Account with this email address already exists. Please use a different email",
+                fieldName = "email",
+                domainClass = ClinicWaveUser.class
+        )
         String email,
 
         @NotNull(message = "Date of birth cannot be null")


### PR DESCRIPTION
### Description:
This pull request introduces custom error messages for the `@UniqueField` annotations in the `ClinicWaveUserDto` class. These messages provide more specific and user-friendly feedback when attempting to create a new `ClinicWaveUser` with duplicate `mobileNumber`, `username`, or `email` values.

### Changes:
- **UniqueField Annotations:** Added custom error messages to the `@UniqueField` annotations for the `mobileNumber`, `username`, and `email` fields in the `ClinicWaveUserDto` class.

### Purpose:
The purpose of this pull request is to improve the user experience by providing more informative and helpful error messages when a user attempts to create a new ClinicWaveUser with a mobile number, username, or email that already exists in the system. By customizing these error messages, we can offer clearer guidance to users on how to resolve the issue, reducing confusion and streamlining the user registration or profile creation process. This change will make our application more user-friendly and potentially reduce support requests related to duplicate field errors.