### PR TITLE
Refactor GlobalExceptionHandler to Use Centralized ErrorResponse Creation

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/exception/GlobalExceptionHandler.java
@@ -42,14 +42,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
           Exception exception,
           WebRequest webRequest
   ) {
-    ErrorResponseDto errorResponseDto = new ErrorResponseDto(
-            webRequest.getDescription(false),
-            HttpStatus.INTERNAL_SERVER_ERROR.value(),
-            exception.getMessage(),
-            LocalDateTime.now()
-    );
-
-    return new ResponseEntity<>(errorResponseDto, HttpStatus.INTERNAL_SERVER_ERROR);
+    return createErrorResponse(exception, webRequest, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
   /**
@@ -60,14 +53,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
           Exception exception,
           WebRequest webRequest
   ) {
-    ErrorResponseDto errorResponseDto = new ErrorResponseDto(
-            webRequest.getDescription(false),
-            HttpStatus.CONFLICT.value(),
-            exception.getMessage(),
-            LocalDateTime.now()
-    );
-
-    return new ResponseEntity<>(errorResponseDto, HttpStatus.CONFLICT);
+    return createErrorResponse(exception, webRequest, HttpStatus.CONFLICT);
   }
 
   /**
@@ -78,14 +64,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
           Exception exception,
           WebRequest webRequest
   ) {
-    ErrorResponseDto errorResponseDto = new ErrorResponseDto(
-            webRequest.getDescription(false),
-            HttpStatus.NOT_FOUND.value(),
-            exception.getMessage(),
-            LocalDateTime.now()
-    );
-
-    return new ResponseEntity<>(errorResponseDto, HttpStatus.NOT_FOUND);
+    return createErrorResponse(exception, webRequest, HttpStatus.NOT_FOUND);
   }
 
   /**
@@ -96,14 +75,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
           Exception exception,
           WebRequest webRequest
   ) {
-    ErrorResponseDto errorResponseDto = new ErrorResponseDto(
-            webRequest.getDescription(false),
-            HttpStatus.BAD_REQUEST.value(),
-            exception.getMessage(),
-            LocalDateTime.now()
-    );
-
-    return new ResponseEntity<>(errorResponseDto, HttpStatus.BAD_REQUEST);
+    return createErrorResponse(exception, webRequest, HttpStatus.BAD_REQUEST);
   }
 
   /**
@@ -114,14 +86,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
           Exception exception,
           WebRequest webRequest
   ) {
-    ErrorResponseDto errorResponseDto = new ErrorResponseDto(
-            webRequest.getDescription(false),
-            HttpStatus.CONFLICT.value(),
-            exception.getMessage(),
-            LocalDateTime.now()
-    );
-
-    return new ResponseEntity<>(errorResponseDto, HttpStatus.CONFLICT);
+    return createErrorResponse(exception, webRequest, HttpStatus.CONFLICT);
   }
 
   /**
@@ -132,14 +97,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
           Exception exception,
           WebRequest webRequest
   ) {
-    ErrorResponseDto errorResponseDto = new ErrorResponseDto(
-            webRequest.getDescription(false),
-            HttpStatus.BAD_REQUEST.value(),
-            exception.getMessage(),
-            LocalDateTime.now()
-    );
-
-    return new ResponseEntity<>(errorResponseDto, HttpStatus.BAD_REQUEST);
+    return createErrorResponse(exception, webRequest, HttpStatus.BAD_REQUEST);
   }
 
   /**
@@ -178,5 +136,20 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     );
 
     return new ResponseEntity<>(validationErrorResponseDto, status);
+  }
+
+  private ResponseEntity<ErrorResponseDto> createErrorResponse(
+          Exception exception,
+          WebRequest webRequest,
+          HttpStatus status
+  ) {
+    ErrorResponseDto errorResponseDto = new ErrorResponseDto(
+            webRequest.getDescription(false),
+            status.value(),
+            exception.getMessage(),
+            LocalDateTime.now()
+    );
+
+    return new ResponseEntity<>(errorResponseDto, status);
   }
 }


### PR DESCRIPTION
### Description:
This pull request introduces a significant refactor to the `GlobalExceptionHandler` class within our application. By centralizing the creation of error responses into a single `createErrorResponse` method, we have streamlined the error handling process across the entire application. This approach not only reduces code duplication but also ensures a consistent structure and content for error responses, enhancing the maintainability and readability of our exception handling mechanism.

### Changes:
- Added a private `createErrorResponse` method in the `GlobalExceptionHandler` class that constructs `ErrorResponseDto` objects and `ResponseEntity` instances. This method is now utilized by all exception handler methods within the class to create error responses.
- Refactored all exception handler methods within the `GlobalExceptionHandler` class to call the `createErrorResponse` method, significantly reducing code duplication and improving the maintainability of the code.
- Ensured consistency in error response structure across different types of exceptions by using the centralized `createErrorResponse` method.

### Purpose:
The purpose of this pull request is to enhance the efficiency and readability of our global exception handling mechanism by centralizing the creation of error responses. This refactor addresses the issue of code duplication within the `GlobalExceptionHandler` class and ensures a consistent approach to constructing error responses. By implementing these changes, we aim to make the class easier to maintain and modify, while also providing a more uniform error response structure to clients. This improvement is a step towards making our application's error handling more robust and user-friendly.