### PR TITLE
Enhance Error Handling and Role Assignment with Inactive User Checks

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/exception/GlobalExceptionHandler.java
@@ -101,6 +101,17 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   }
 
   /**
+   * Handles InactiveUserException.
+   */
+  @ExceptionHandler(InactiveUserException.class)
+  public ResponseEntity<ErrorResponseDto> handleInactiveUserException(
+          Exception exception,
+          WebRequest webRequest
+  ) {
+    return createErrorResponse(exception, webRequest, HttpStatus.BAD_REQUEST);
+  }
+
+  /**
    * Handles MethodArgumentNotValidException.
    * This exception is thrown when validation on an argument annotated with @Valid fails.
    *

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/exception/InactiveUserException.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/exception/InactiveUserException.java
@@ -1,0 +1,26 @@
+package com.clinicwave.clinicwaveusermanagementservice.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * This class represents a custom exception that is thrown when a user is inactive.
+ * It is annotated with @ResponseStatus to automatically return a HttpStatus.BAD_REQUEST when thrown.
+ * The exception takes in resourceName, fieldName, and fieldValue as parameters to construct a detailed error message.
+ * The exception is thrown when a user is inactive.
+ *
+ * @author aamir on 7/7/24
+ */
+@ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Inactive user")
+public class InactiveUserException extends RuntimeException {
+  /**
+   * Constructs a new InactiveUserException with the specified detail message.
+   *
+   * @param resourceName the name of the resource that is inactive
+   * @param fieldName    the name of the field that caused the conflict
+   * @param fieldValue   the value of the field that caused the conflict
+   */
+  public InactiveUserException(String resourceName, String fieldName, Long fieldValue) {
+    super(String.format("%s with %s %d is inactive", resourceName, fieldName, fieldValue));
+  }
+}

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserRoleAssignmentImpl.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserRoleAssignmentImpl.java
@@ -4,10 +4,8 @@ import com.clinicwave.clinicwaveusermanagementservice.domain.ClinicWaveUser;
 import com.clinicwave.clinicwaveusermanagementservice.domain.Role;
 import com.clinicwave.clinicwaveusermanagementservice.dto.ClinicWaveUserRoleAssignmentDto;
 import com.clinicwave.clinicwaveusermanagementservice.enums.RoleNameEnum;
-import com.clinicwave.clinicwaveusermanagementservice.exception.DefaultRoleRemovalException;
-import com.clinicwave.clinicwaveusermanagementservice.exception.DuplicateRoleAssignmentException;
-import com.clinicwave.clinicwaveusermanagementservice.exception.ResourceNotFoundException;
-import com.clinicwave.clinicwaveusermanagementservice.exception.RoleMismatchException;
+import com.clinicwave.clinicwaveusermanagementservice.enums.UserStatusEnum;
+import com.clinicwave.clinicwaveusermanagementservice.exception.*;
 import com.clinicwave.clinicwaveusermanagementservice.repository.ClinicWaveUserRepository;
 import com.clinicwave.clinicwaveusermanagementservice.repository.RoleRepository;
 import com.clinicwave.clinicwaveusermanagementservice.service.ClinicWaveUserRoleAssignment;
@@ -58,6 +56,11 @@ public class ClinicWaveUserRoleAssignmentImpl implements ClinicWaveUserRoleAssig
     ClinicWaveUser clinicWaveUser = findClinicWaveUserById(userId);
     Role role = findRoleById(roleId);
 
+    // Check if the user is inactive
+    if (isUserInactive(clinicWaveUser)) {
+      throw new InactiveUserException("User", "id", userId);
+    }
+
     // Check if the role to be assigned is the user's current role
     if (isCurrentRole(roleId, clinicWaveUser.getRole().getId())) {
       throw new DuplicateRoleAssignmentException("User", "id", userId, role.getRoleName());
@@ -94,6 +97,11 @@ public class ClinicWaveUserRoleAssignmentImpl implements ClinicWaveUserRoleAssig
     ClinicWaveUser clinicWaveUser = findClinicWaveUserById(userId);
     Role role = findRoleById(roleId);
 
+    // Check if the user is inactive
+    if (isUserInactive(clinicWaveUser)) {
+      throw new InactiveUserException("User", "id", userId);
+    }
+
     // Check if the role to be de-provisioned matches the user's current role
     if (!isCurrentRole(roleId, clinicWaveUser.getRole().getId())) {
       throw new RoleMismatchException("Role", "roleId", roleId);
@@ -115,6 +123,10 @@ public class ClinicWaveUserRoleAssignmentImpl implements ClinicWaveUserRoleAssig
             defaultRole.getRoleName(),
             LocalDateTime.now()
     );
+  }
+
+  private boolean isUserInactive(ClinicWaveUser user) {
+    return user.getStatus() != UserStatusEnum.ACTIVE;
   }
 
   /**

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserRoleAssignmentImpl.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserRoleAssignmentImpl.java
@@ -125,6 +125,11 @@ public class ClinicWaveUserRoleAssignmentImpl implements ClinicWaveUserRoleAssig
     );
   }
 
+  /**
+   * Checks if the specified ClinicWaveUser entity is inactive.
+   * @param user the ClinicWaveUser entity to be checked
+   * @return true if the ClinicWaveUser entity is inactive, false otherwise
+   */
   private boolean isUserInactive(ClinicWaveUser user) {
     return user.getStatus() != UserStatusEnum.ACTIVE;
   }


### PR DESCRIPTION
### Description:
This pull request introduces significant enhancements to the application's error handling and user role assignment functionalities. By adding a new custom exception, `InactiveUserException`, and integrating it into the `GlobalExceptionHandler`, the application now gracefully handles scenarios where operations are attempted on inactive users. Additionally, the role assignment logic within `ClinicWaveUserRoleAssignmentImpl` has been improved to check for user activity status before proceeding with role assignment or de-assignment, ensuring that such operations are only performed on active users.

### Changes:
- Added `InactiveUserException` to handle inactive user scenarios, automatically returning a `HttpStatus.BAD_REQUEST`.
- Integrated `InactiveUserException` handling into the `GlobalExceptionHandler` to ensure a consistent error response.
- Optimized import statements in `ClinicWaveUserRoleAssignmentImpl` for better readability and maintainability.
- Added checks in `provisionUser` and `deProvisionUser` methods to prevent role assignment and de-assignment for inactive users.
- Introduced a `isUserInactive` method to centralize the determination of a user's activity status.
- Implement Inactive User Checks in ClinicWaveUserRoleAssignmentImplTest

### Purpose:
The purpose of this pull request is to significantly improve the application's robustness and user experience by ensuring that operations related to error handling and user role assignments are conducted in a manner that is both secure and consistent. By introducing checks for user activity status and handling inactive user scenarios more gracefully, the application not only adheres to best practices in error handling but also enhances its security posture by preventing unauthorized or inappropriate changes to user roles. This comprehensive approach to managing user states and errors ensures that the application remains reliable and maintainable, thereby supporting a seamless user experience.