### PR TITLE
Refactor isUserInactive method to send UserStatusEnum in ClinicWaveUserRoleAssignmentImpl

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserRoleAssignmentImpl.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserRoleAssignmentImpl.java
@@ -57,7 +57,7 @@ public class ClinicWaveUserRoleAssignmentImpl implements ClinicWaveUserRoleAssig
     Role role = findRoleById(roleId);
 
     // Check if the user is inactive
-    if (isUserInactive(clinicWaveUser)) {
+    if (isUserInactive(clinicWaveUser.getStatus())) {
       throw new InactiveUserException("User", "id", userId);
     }
 
@@ -98,7 +98,7 @@ public class ClinicWaveUserRoleAssignmentImpl implements ClinicWaveUserRoleAssig
     Role role = findRoleById(roleId);
 
     // Check if the user is inactive
-    if (isUserInactive(clinicWaveUser)) {
+    if (isUserInactive(clinicWaveUser.getStatus())) {
       throw new InactiveUserException("User", "id", userId);
     }
 
@@ -127,11 +127,12 @@ public class ClinicWaveUserRoleAssignmentImpl implements ClinicWaveUserRoleAssig
 
   /**
    * Checks if the specified ClinicWaveUser entity is inactive.
-   * @param user the ClinicWaveUser entity to be checked
+   *
+   * @param status the status of the ClinicWaveUser entity to be checked
    * @return true if the ClinicWaveUser entity is inactive, false otherwise
    */
-  private boolean isUserInactive(ClinicWaveUser user) {
-    return user.getStatus() != UserStatusEnum.ACTIVE;
+  private boolean isUserInactive(UserStatusEnum status) {
+    return status != UserStatusEnum.ACTIVE;
   }
 
   /**


### PR DESCRIPTION
### Description:
This pull request introduces a significant refactor to the `isUserInactive` method within the `ClinicWaveUserRoleAssignmentImpl` class, alongside updates to its usage across the class. The method's signature has been modified to accept a `UserStatusEnum` parameter directly instead of a `ClinicWaveUser` object. This change streamlines the method's functionality and focuses its purpose on evaluating the user's status.

### Changes:
- Modified the `isUserInactive` method to accept `UserStatusEnum` as its parameter, enhancing the method's clarity and efficiency.
- Updated the `provisionUser` and `deProvisionUser` methods to pass the `UserStatusEnum` directly to the `isUserInactive` method, aligning with the refactor and reducing the dependency on the `ClinicWaveUser` class within these methods.

### Purpose:
The purpose of this pull request is to refine the implementation of the `isUserInactive` method, making it more efficient and focused by directly utilizing the `UserStatusEnum`. This adjustment not only simplifies the logic within the `ClinicWaveUserRoleAssignmentImpl` class but also enhances the maintainability and readability of the code. By reducing the coupling between the `isUserInactive` method and the `ClinicWaveUser` class, this refactor facilitates easier modifications and testing in the future, contributing to the overall robustness and quality of the user role management functionality.