### PR TITLE
Add Verification Link Generation in ClinicWaveUserServiceImpl and ClinicWaveUserServiceImplTest

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,6 @@ spring.profiles.active=dev
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+# ClinicWave User Management frontend application base URL
+clinicwave-user-management-frontend-base-url=http://localhost:5173


### PR DESCRIPTION
### Description:
This pull request introduces the generation of verification links in the `ClinicWaveUserServiceImpl` class and adds corresponding tests in the `ClinicWaveUserServiceImplTest` class.

### Changes:
- Added `clinicwaveUserManagementFrontendBaseUrl` property to `application.properties`.
- Injected `clinicwaveUserManagementFrontendBaseUrl` property into `ClinicWaveUserServiceImpl`.
- Added `generateVerificationLink` method to `ClinicWaveUserServiceImpl` to generate a verification link for the user.
- Updated `createUser` method in `ClinicWaveUserServiceImpl` to include the generated verification link in the notification request.
- Added `ReflectionTestUtils.setField` to set `clinicwaveUserManagementFrontendBaseUrl` in `setUp` method of `ClinicWaveUserServiceImplTest`.
- Added imports for `ReflectionTestUtils`, `URLEncoder`, and `StandardCharsets` in `ClinicWaveUserServiceImplTest`.
- Added verification of the generated verification link in the `createUser_returnsCreatedClinicWaveUserDto` test in `ClinicWaveUserServiceImplTest`.
- Updated `expectedTemplateVariables` to include `verificationLink` in `ClinicWaveUserServiceImplTest`.

### Purpose:
The purpose of this pull request is to enhance the user verification process by generating a verification link and including it in the notification sent to the user. Additionally, it ensures that the verification link generation is properly tested, improving the robustness and reliability of the user management service.