### PR TITLE
Remove `@CrossOrigin` Annotation from VerificationCodeController

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/controller/VerificationCodeController.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/controller/VerificationCodeController.java
@@ -6,7 +6,10 @@ import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
@@ -18,7 +21,6 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/verification")
 @Slf4j
-@CrossOrigin
 public class VerificationCodeController {
   private final VerificationCodeService verificationCodeService;
 


### PR DESCRIPTION
### Description:
This pull request introduces the removal of the `@CrossOrigin` annotation from the `VerificationCodeController` class. CORS configuration is now managed globally through the `WebConfig` class to streamline and centralize CORS settings.

### Changes:
- Removed `@CrossOrigin` annotation from `VerificationCodeController`.
- Updated imports to remove unused entries.

### Purpose:
The purpose of this pull request is to centralize CORS configuration by removing the `@CrossOrigin` annotation from individual controllers. By managing CORS settings globally in the `WebConfig` class, we ensure a more maintainable and consistent approach to handling cross-origin requests across the entire application.
