### PR TITLE
Refactor Exception Handling and Update Unit Tests for VerificationCodeController

### DIFF
--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/controller/VerificationCodeControllerTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/controller/VerificationCodeControllerTest.java
@@ -96,7 +96,7 @@ class VerificationCodeControllerTest {
                     .param("email", "testuser@example.com")
                     .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.error").value("ClinicWaveUser with email: testuser@example.com not found"));
+            .andExpect(jsonPath("$.errorMessage").value("ClinicWaveUser with email: testuser@example.com not found"));
   }
 
   @Test
@@ -108,8 +108,8 @@ class VerificationCodeControllerTest {
     mockMvc.perform(get(URL_TEMPLATE)
                     .param("email", "testuser@example.com")
                     .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").value("Unexpected error"));
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.errorMessage").value("Unexpected error"));
   }
 
   @Test
@@ -138,7 +138,7 @@ class VerificationCodeControllerTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(verificationRequestDto)))
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").value(String.format("VerificationCode with code %s is invalid", verificationRequestDto.code())));
+            .andExpect(jsonPath("$.errorMessage").value(String.format("VerificationCode with code %s is invalid", verificationRequestDto.code())));
   }
 
   @Test
@@ -152,8 +152,8 @@ class VerificationCodeControllerTest {
     mockMvc.perform(post(URL_TEMPLATE)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(verificationRequestDto)))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").value(String.format("VerificationCode with code %s has already been used", verificationRequestDto.code())));
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.errorMessage").value(String.format("VerificationCode with code %s has already been used", verificationRequestDto.code())));
   }
 
   @Test
@@ -167,8 +167,8 @@ class VerificationCodeControllerTest {
     mockMvc.perform(post(URL_TEMPLATE)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(verificationRequestDto)))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").value(String.format("VerificationCode with code %s has expired", verificationRequestDto.code())));
+            .andExpect(status().isGone())
+            .andExpect(jsonPath("$.errorMessage").value(String.format("VerificationCode with code %s has expired", verificationRequestDto.code())));
   }
 
   @Test
@@ -182,7 +182,7 @@ class VerificationCodeControllerTest {
     mockMvc.perform(post(URL_TEMPLATE)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(verificationRequestDto)))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").value(String.format("ClinicWaveUser with email: %s not found", verificationRequestDto.email())));
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.errorMessage").value(String.format("ClinicWaveUser with email: %s not found", verificationRequestDto.email())));
   }
 }


### PR DESCRIPTION
### Description:
This pull request introduces changes to both the `VerificationCodeController` and its unit tests. The changes focus on refactoring exception handling and updating error response assertions.

### Changes:
- Removed try-catch blocks from the `checkVerificationStatus` and `verifyAccount` methods in `VerificationCodeController`.
- Added comments to the `checkVerificationStatus` and `verifyAccount` methods to indicate that exceptions will be handled by the GlobalExceptionHandler.
- Updated the `checkVerificationStatus` and `verifyAccount` methods to directly return responses without internal exception handling.
- Updated error response assertions in `VerificationCodeControllerTest` to use `errorMessage` instead of `error`.
- Adjusted status codes in unit tests to reflect the correct HTTP status codes based on the exception type:
  - Changed `status().isNotFound()` and `errorMessage` for not found scenarios.
  - Updated `status().isInternalServerError()` and `errorMessage` for unexpected errors.
  - Corrected `status().isBadRequest()` for invalid verification code errors.
  - Changed `status().isConflict()` and `errorMessage` for already used verification codes.
  - Updated `status().isGone()` and `errorMessage` for expired verification codes.
  - Changed `status().isNotFound()` and `errorMessage` for user not found scenarios in verification requests.

### Purpose:
The purpose of this pull request is to refactor exception handling in the `VerificationCodeController` to rely on global exception handling via `GlobalExceptionHandler`. This ensures that exceptions are managed consistently and responses follow the `ErrorResponseDto` format. Additionally, the pull request updates unit tests to validate the error messages and status codes correctly, ensuring that they align with the new global exception handling approach.

This pull request fixes #67.
