### PR TITLE
Use token instead of email for verifying account and checking verification status

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/controller/VerificationCodeController.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/controller/VerificationCodeController.java
@@ -1,6 +1,7 @@
 package com.clinicwave.clinicwaveusermanagementservice.controller;
 
 import com.clinicwave.clinicwaveusermanagementservice.dto.VerificationRequestDto;
+import com.clinicwave.clinicwaveusermanagementservice.dto.VerificationStatusDto;
 import com.clinicwave.clinicwaveusermanagementservice.service.VerificationCodeService;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
@@ -32,17 +33,17 @@ public class VerificationCodeController {
   }
 
   /**
-   * Checks the verification status for the specified email address.
+   * Checks the verification status for the specified token.
    *
-   * @param email the email address to check the verification status for
-   * @return the response entity containing the verification status
+   * @param token the token to check the verification status for
+   * @return the response entity containing the VerificationStatusDto object
    * Throws exception which is handled by the GlobalExceptionHandler:
    * - ResourceNotFoundException if the user is not found
    */
   @GetMapping("/verify")
-  public ResponseEntity<Map<String, Object>> checkVerificationStatus(@RequestParam String email) {
-    Boolean isVerified = verificationCodeService.checkVerificationStatus(email);
-    return ResponseEntity.ok(Map.of("isVerified", isVerified));
+  public ResponseEntity<VerificationStatusDto> checkVerificationStatus(@RequestParam String token) {
+    VerificationStatusDto verificationStatusDto = verificationCodeService.checkVerificationStatus(token);
+    return ResponseEntity.ok(verificationStatusDto);
   }
 
   /**

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/domain/VerificationCode.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/domain/VerificationCode.java
@@ -49,6 +49,9 @@ public class VerificationCode extends Audit {
   @Column(nullable = false)
   private VerificationCodeTypeEnum type;
 
+  @Column(nullable = false, unique = true)
+  private String token;
+
   @ManyToOne
   @JoinColumn(nullable = false)
   @OnDelete(action = OnDeleteAction.CASCADE)

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/VerificationStatusDto.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/dto/VerificationStatusDto.java
@@ -1,0 +1,7 @@
+package com.clinicwave.clinicwaveusermanagementservice.dto;
+
+/**
+* @author aamir on 8/15/24
+*/
+public record VerificationStatusDto(Boolean isVerified, String email) {
+}

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/repository/VerificationCodeRepository.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/repository/VerificationCodeRepository.java
@@ -17,5 +17,7 @@ import java.util.Optional;
 public interface VerificationCodeRepository extends JpaRepository<VerificationCode, Long> {
   List<VerificationCode> findAllByClinicWaveUser(ClinicWaveUser clinicWaveUser);
 
+  Optional<VerificationCode> findByToken(String token);
+
   Optional<VerificationCode> findTopByClinicWaveUserAndTypeOrderByCreatedAtDesc(ClinicWaveUser clinicWaveUser, VerificationCodeTypeEnum type);
 }

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/VerificationCodeService.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/VerificationCodeService.java
@@ -3,6 +3,7 @@ package com.clinicwave.clinicwaveusermanagementservice.service;
 import com.clinicwave.clinicwaveusermanagementservice.domain.ClinicWaveUser;
 import com.clinicwave.clinicwaveusermanagementservice.domain.VerificationCode;
 import com.clinicwave.clinicwaveusermanagementservice.dto.VerificationRequestDto;
+import com.clinicwave.clinicwaveusermanagementservice.dto.VerificationStatusDto;
 import com.clinicwave.clinicwaveusermanagementservice.enums.VerificationCodeTypeEnum;
 
 /**
@@ -15,7 +16,7 @@ import com.clinicwave.clinicwaveusermanagementservice.enums.VerificationCodeType
 public interface VerificationCodeService {
   VerificationCode getVerificationCode(ClinicWaveUser clinicWaveUser, VerificationCodeTypeEnum verificationCodeType);
 
-  Boolean checkVerificationStatus(String email);
+  VerificationStatusDto checkVerificationStatus(String token);
 
   void verifyAccount(VerificationRequestDto verificationRequestDto);
 }

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserServiceImpl.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserServiceImpl.java
@@ -22,8 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -96,7 +94,7 @@ public class ClinicWaveUserServiceImpl implements ClinicWaveUserService {
     VerificationCode verificationCode = generateVerificationCode(savedClinicWaveUser);
 
     // Generate a verification link for the user
-    String verificationLink = generateVerificationLink(clinicWaveUser.getEmail());
+    String verificationLink = generateVerificationLink(verificationCode.getToken());
 
     // Send a notification to the user with the verification code
     sendVerificationNotification(savedClinicWaveUser, verificationCode, verificationLink);
@@ -179,15 +177,14 @@ public class ClinicWaveUserServiceImpl implements ClinicWaveUserService {
   }
 
   /**
-   * Generates a verification link for the user based on their email.
+   * Generates a verification link for the user based on the specified token.
    * clinicwaveUserManagementFrontendBaseUrl is the base URL of the ClinicWave User Management frontend application.
-   * The email is encoded using UTF-8 to ensure that special characters are handled correctly.
    *
-   * @param email the email of the user for whom the verification link is to be generated
+   * @param token the token to be used in the verification link
    * @return the generated verification link
    */
-  private String generateVerificationLink(String email) {
-    return clinicwaveUserManagementFrontendBaseUrl + "/verification/verify?email=" + URLEncoder.encode(email, StandardCharsets.UTF_8);
+  private String generateVerificationLink(String token) {
+    return clinicwaveUserManagementFrontendBaseUrl + "/verification/verify?token=" + token;
   }
 
   /**

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/VerificationCodeTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/domain/VerificationCodeTest.java
@@ -63,6 +63,7 @@ class VerificationCodeTest {
     verificationCode = new VerificationCode();
     verificationCode.setCode("123456");
     verificationCode.setType(VerificationCodeTypeEnum.EMAIL_VERIFICATION);
+    verificationCode.setToken("123456");
     verificationCode.setClinicWaveUser(user);
   }
 
@@ -91,6 +92,7 @@ class VerificationCodeTest {
     assertNotNull(savedVerificationCode);
     assertEquals(verificationCode.getCode(), savedVerificationCode.getCode());
     assertEquals(verificationCode.getType(), savedVerificationCode.getType());
+    assertEquals(verificationCode.getToken(), savedVerificationCode.getToken());
     assertEquals(verificationCode.getClinicWaveUser().getId(), savedVerificationCode.getClinicWaveUser().getId());
   }
 
@@ -110,6 +112,7 @@ class VerificationCodeTest {
     VerificationCode anotherCode = new VerificationCode();
     anotherCode.setCode("654321");
     anotherCode.setType(VerificationCodeTypeEnum.PASSWORD_RESET);
+    anotherCode.setToken("654321");
     anotherCode.setClinicWaveUser(user);
     verificationCodeRepository.save(anotherCode);
 

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserServiceImplTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserServiceImplTest.java
@@ -24,8 +24,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
@@ -126,9 +124,12 @@ class ClinicWaveUserServiceImplTest {
   @Test
   @DisplayName("createUser returns created ClinicWaveUser")
   void createUser_returnsCreatedClinicWaveUserDto() {
+    String token = "91cd894d-7c2b-41d8-92cf-7ecb17b931ea";
+
     VerificationCode verificationCode = new VerificationCode();
     verificationCode.setCode("123456");
     verificationCode.setType(VerificationCodeTypeEnum.EMAIL_VERIFICATION);
+    verificationCode.setToken(token);
     verificationCode.setClinicWaveUser(clinicWaveUser);
 
     when(clinicWaveUserMapper.toEntity(clinicWaveUserDto)).thenReturn(clinicWaveUser);
@@ -153,8 +154,7 @@ class ClinicWaveUserServiceImplTest {
     ArgumentCaptor<NotificationRequestDto> notificationCaptor = ArgumentCaptor.forClass(NotificationRequestDto.class);
     verify(notificationServiceClient, times(1)).sendNotification(notificationCaptor.capture());
 
-    String encodedEmail = URLEncoder.encode(clinicWaveUser.getEmail(), StandardCharsets.UTF_8);
-    String expectedVerificationLink = "http://localhost:5173/verification/verify?email=" + encodedEmail;
+    String expectedVerificationLink = "http://localhost:5173/verification/verify?token=" + token;
 
     // Verify notification details
     NotificationRequestDto capturedNotification = notificationCaptor.getValue();


### PR DESCRIPTION
### Description:
This pull request introduces significant changes to the `ClinicWaveUserServiceImpl`, `VerificationCodeController`, and `VerificationCodeService` to handle verification links and status checks using tokens instead of emails. Additionally, it updates the corresponding unit tests to reflect these changes.

### Changes:
- **VerificationCode Entity:**
  - Added a new `token` field to the `VerificationCode` entity.
  - Ensured that the `token` field is unique and not nullable.
  - Updated unit tests to include the `token` field.

- **VerificationStatusDto:**
  - Created `VerificationStatusDto` to encapsulate verification status responses.

- **VerificationCodeService:**
  - Modified the `checkVerificationStatus` method to accept a token instead of an email.
  - Added a method to generate a unique token for each verification code.
  - Updated the repository to include a method for finding a verification code by token.
  - Updated unit tests to use the `token` and `VerificationStatusDto`.

- **VerificationCodeController:**
  - Updated the `checkVerificationStatus` endpoint to take a token as a parameter.
  - The endpoint now returns a `VerificationStatusDto` instead of a simple map.
  - Modified unit tests in `VerificationCodeControllerTest` to reflect the changes from email to token.

- **ClinicWaveUserServiceImpl:**
  - Updated the `generateVerificationLink` method to use the token instead of the email.
  - Adjusted the logic for sending verification notifications to include the token in the link.
  - Removed `URLEncoder` and `StandardCharsets` imports.
  - Updated the `createUser_returnsCreatedClinicWaveUserDto` test to handle token generation and verification link creation.

### Purpose:
The purpose of this pull request is to enhance the security and accuracy of the verification process by using unique tokens instead of emails. This approach prevents the misuse of email addresses and ensures that verification links are tied to specific verification requests, improving the overall user experience and system reliability.

This pull request fixes #69.