### PR TITLE
Implement Kafka Producer for Notification Events

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,27 @@ services:
         volumes:
             - ./data:/var/lib/postgresql/data
         ports:
-            - 5432:5432
+            - "5432:5432"
+
+    zookeeper:
+        image: confluentinc/cp-zookeeper:latest
+        environment:
+            ZOOKEEPER_CLIENT_PORT: 2182
+            ZOOKEEPER_TICK_TIME: 2000
+        ports:
+            - "2182:2182"
+
+    kafka:
+        image: confluentinc/cp-kafka:latest
+        depends_on:
+            - zookeeper
+        environment:
+            KAFKA_BROKER_ID: 1
+            KAFKA_ZOOKEEPER_CONNECT: zookeeper:2182
+            KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9093,PLAINTEXT_HOST://localhost:29093
+            KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+            KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+            KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+        ports:
+            - "9093:9093"
+            - "29093:29093"

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@
 			<artifactId>spring-kafka-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>kafka</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,15 @@
 			<artifactId>postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/config/KafkaProducerConfig.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/config/KafkaProducerConfig.java
@@ -1,0 +1,52 @@
+package com.clinicwave.clinicwaveusermanagementservice.config;
+
+import com.clinicwave.clinicwaveusermanagementservice.dto.NotificationRequestDto;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class is responsible for configuring the Kafka Producer.
+ * It sets the bootstrap servers, key serializer and value serializer.
+ *
+ * @author aamir on 8/21/24
+ */
+@Configuration
+public class KafkaProducerConfig {
+  @Value("${spring.kafka.bootstrap-servers}")
+  private String bootstrapServers;
+
+  /**
+   * This method creates a ProducerFactory object with the configuration properties.
+   *
+   * @return ProducerFactory object
+   */
+  @Bean
+  public ProducerFactory<String, NotificationRequestDto> producerFactory() {
+    Map<String, Object> configProps = new HashMap<>();
+    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    configProps.put(JsonSerializer.TYPE_MAPPINGS, "notificationRequest:com.clinicwave.clinicwaveusermanagementservice.dto.NotificationRequestDto");
+    return new DefaultKafkaProducerFactory<>(configProps);
+  }
+
+  /**
+   * This method creates a KafkaTemplate object with the ProducerFactory object.
+   *
+   * @return KafkaTemplate object
+   */
+  @Bean
+  public KafkaTemplate<String, NotificationRequestDto> kafkaTemplate() {
+    return new KafkaTemplate<>(producerFactory());
+  }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -9,3 +9,6 @@ spring.h2.console.enabled=true
 
 # JPA database platform configuration
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+# Kafka configuration
+spring.kafka.bootstrap-servers=localhost:9092

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -6,3 +6,6 @@ spring.datasource.password=root
 
 # JPA database platform configuration
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+
+# Kafka configuration
+spring.kafka.bootstrap-servers=localhost:9093

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,8 +1,0 @@
-# Datasource configuration
-spring.datasource.url=jdbc:postgresql://localhost:5432/clinicwave-user-management
-spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.username=root
-spring.datasource.password=root
-
-# JPA database platform configuration
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/config/KafkaProducerConfigTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/config/KafkaProducerConfigTest.java
@@ -1,0 +1,86 @@
+package com.clinicwave.clinicwaveusermanagementservice.config;
+
+import com.clinicwave.clinicwaveusermanagementservice.dto.NotificationRequestDto;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This class tests the KafkaProducerConfig class.
+ * It tests the configuration of the ProducerFactory and KafkaTemplate beans.
+ *
+ * @author aamir on 8/25/24
+ */
+@SpringBootTest
+class KafkaProducerConfigTest {
+  @Value("${spring.kafka.bootstrap-servers}")
+  private String bootstrapServers;
+
+  private final KafkaProducerConfig kafkaProducerConfig;
+  private final ProducerFactory<String, NotificationRequestDto> producerFactory;
+  private final KafkaTemplate<String, NotificationRequestDto> kafkaTemplate;
+
+  /**
+   * Constructor for dependency injection.
+   *
+   * @param kafkaProducerConfig The KafkaProducerConfig object to be tested
+   * @param producerFactory     The ProducerFactory object to be tested
+   * @param kafkaTemplate       The KafkaTemplate object to be tested
+   */
+  @Autowired
+  public KafkaProducerConfigTest(KafkaProducerConfig kafkaProducerConfig, ProducerFactory<String, NotificationRequestDto> producerFactory, KafkaTemplate<String, NotificationRequestDto> kafkaTemplate) {
+    this.kafkaProducerConfig = kafkaProducerConfig;
+    this.producerFactory = producerFactory;
+    this.kafkaTemplate = kafkaTemplate;
+  }
+
+  @Test
+  @DisplayName("Test KafkaProducerConfig bean")
+  void testKafkaProducerConfig() {
+    assertNotNull(kafkaProducerConfig);
+  }
+
+  @Test
+  @DisplayName("Test KafkaProducerConfig properties")
+  void testProducerFactoryConfiguration() {
+    assertNotNull(producerFactory);
+
+    // Test if the ProducerFactory is correctly configured
+    Map<String, Object> configs = producerFactory.getConfigurationProperties();
+
+    assertEquals(bootstrapServers, configs.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+    assertEquals(StringSerializer.class, configs.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG));
+    assertEquals(JsonSerializer.class, configs.get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG));
+    assertEquals("notificationRequest:com.clinicwave.clinicwaveusermanagementservice.dto.NotificationRequestDto",
+            configs.get(JsonSerializer.TYPE_MAPPINGS));
+  }
+
+  @Test
+  @DisplayName("Test KafkaTemplate properties")
+  void testKafkaTemplateConfiguration() {
+    assertNotNull(kafkaTemplate);
+    assertEquals(producerFactory, kafkaTemplate.getProducerFactory());
+  }
+
+  /**
+   * This test demonstrates that the KafkaTemplate can serialize and send a message
+   * Note: This doesn't actually send a message to Kafka, it just checks if the operation doesn't throw an exception
+   */
+  @Test
+  @DisplayName("Test KafkaTemplate send message")
+  void testSendMessage() {
+    NotificationRequestDto dto = new NotificationRequestDto("test@example.com", "Test Subject", "Test Template", Map.of(), null, null);
+    assertDoesNotThrow(() -> kafkaTemplate.send("test-topic", dto));
+  }
+}

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/config/KafkaTemplateMockConfig.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/config/KafkaTemplateMockConfig.java
@@ -1,0 +1,28 @@
+package com.clinicwave.clinicwaveusermanagementservice.config;
+
+import com.clinicwave.clinicwaveusermanagementservice.dto.NotificationRequestDto;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * This class provides a mock KafkaTemplate bean for testing purposes.
+ *
+ * @author aamir on 8/25/24
+ */
+@TestConfiguration
+public class KafkaTemplateMockConfig {
+  /**
+   * Creates a mock KafkaTemplate bean.
+   *
+   * @return a mock KafkaTemplate bean
+   */
+  @Bean
+  @Primary
+  public KafkaTemplate<String, NotificationRequestDto> mockKafkaTemplate() {
+    return mock(KafkaTemplate.class);
+  }
+}

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserServiceImplTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserServiceImplTest.java
@@ -1,6 +1,5 @@
 package com.clinicwave.clinicwaveusermanagementservice.service.impl;
 
-import com.clinicwave.clinicwaveusermanagementservice.client.NotificationServiceClient;
 import com.clinicwave.clinicwaveusermanagementservice.domain.ClinicWaveUser;
 import com.clinicwave.clinicwaveusermanagementservice.domain.Role;
 import com.clinicwave.clinicwaveusermanagementservice.domain.UserType;
@@ -22,6 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
@@ -58,7 +58,7 @@ class ClinicWaveUserServiceImplTest {
   private VerificationCodeService verificationCodeService;
 
   @Mock
-  private NotificationServiceClient notificationServiceClient;
+  private KafkaTemplate<String, NotificationRequestDto> kafkaTemplate;
 
   @InjectMocks
   private ClinicWaveUserServiceImpl clinicWaveUserService;
@@ -152,7 +152,7 @@ class ClinicWaveUserServiceImplTest {
 
     // Verify notification was sent and capture the argument
     ArgumentCaptor<NotificationRequestDto> notificationCaptor = ArgumentCaptor.forClass(NotificationRequestDto.class);
-    verify(notificationServiceClient, times(1)).sendNotification(notificationCaptor.capture());
+    verify(kafkaTemplate, times(1)).send(eq("notification-topic"), notificationCaptor.capture());
 
     String expectedVerificationLink = "http://localhost:5173/verification/verify?token=" + token;
 


### PR DESCRIPTION
### Description:
This pull request introduces Kafka Testcontainers support for integration tests, ensuring that notifications are sent via Kafka instead of the previous Notification Service Client. The integration tests are updated to use a mock KafkaTemplate, ensuring that the Kafka producer configurations are correctly tested, verified, and isolated from the local environment. The changes also include setting up Kafka infrastructure within Docker Compose to facilitate seamless testing and decoupling of notification logic from user management operations.

### Changes:
- Added Kafka and Zookeeper services to `docker-compose.yml` with appropriate configurations, including port mappings and environment variable updates.
- Updated Kafka bootstrap server configurations in `application-dev.properties` and created `application-docker.properties` for the Docker environment.
- Added `KafkaProducerConfig` class for Kafka producer configuration:
  - Configured producer properties, including bootstrap servers, key serializer, and value serializer.
  - Implemented `ProducerFactory` and `KafkaTemplate` beans.
  - Created `KafkaProducerConfigTest` to test producer configuration and message sending.
- Removed `NotificationServiceClient` dependency from `ClinicWaveUserServiceImpl` and replaced it with `KafkaTemplate` for sending notifications.
- Updated `ClinicWaveUserServiceImplTest` to mock `KafkaTemplate` and verify that notifications are sent via `KafkaTemplate`.
- Added `KafkaTemplateMockConfig` class to provide a mock KafkaTemplate bean for testing purposes.
- Updated `ClinicWaveUserControllerIntegrationTest`:
  - Imported `KafkaTemplateMockConfig` instead of `NotificationServiceClientMockConfig`.
  - Modified the constructor to include a KafkaTemplate parameter for dependency injection.
  - Verified that the `KafkaTemplate.send` method was called with the expected topic and notification request DTO.
- Added Kafka bootstrap servers configuration to dynamic property source.
- Updated `ClinicWaveUserControllerTestContainersIntegrationTest` class:
  - Added Kafka container configuration.
  - Imported `KafkaTemplateMockConfig` instead of `NotificationServiceClientMockConfig`.
  - Added KafkaTemplate dependency and verification.
  - Changed the active profile from "local" to "docker".
- Removed `application-local.properties` file.
- Added Testcontainers Kafka dependency to `pom.xml`.

### Purpose:
The purpose of this pull request is to enhance the User Management Service by implementing Kafka as the messaging backbone for publishing notification events. This improvement replaces the previous NotificationClient with KafkaTemplate, thereby decoupling the notification logic from user management operations and enhancing system scalability. Kafka Testcontainers support allows the integration tests to run in an isolated environment, ensuring accurate testing of Kafka producer functionality without the need for local Kafka instances. The inclusion of Docker Compose configurations further supports consistent testing and development across different environments.

This PR solves issue #72.
