### PR TITLE
Replace Hardcoded Credentials in `application-prod.properties` and `application-docker.properties`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ src/test/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/RoleSe
 src/test/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/UserTypeServiceImplTest.java
 src/main/java/com/clinicwave/clinicwaveusermanagementservice/util/UrlUtil.java
 src/test/java/com/clinicwave/clinicwaveusermanagementservice/util/UrlUtilTest.java
+src/test/java/com/clinicwave/clinicwaveusermanagementservice/controller/VerificationCodeControllerTest.java
+src/test/java/com/clinicwave/clinicwaveusermanagementservice/controller/VerificationCodeControllerTestV2.java
+
+src/main/resources/secrets.properties
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
         restart: always
         environment:
             POSTGRES_DB: clinicwave-user-management
-            POSTGRES_USER: root
-            POSTGRES_PASSWORD: root
+            POSTGRES_USER: ${DOCKER_POSTGRES_USERNAME}
+            POSTGRES_PASSWORD: ${DOCKER_POSTGRES_PASSWORD}
         volumes:
             - ./data:/var/lib/postgresql/data
         ports:

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -1,8 +1,8 @@
 # Datasource configuration
 spring.datasource.url=jdbc:postgresql://localhost:5432/clinicwave-user-management
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.username=${DOCKER_POSTGRES_USERNAME}
+spring.datasource.password=${DOCKER_POSTGRES_PASSWORD}
 
 # JPA database platform configuration
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,8 +1,8 @@
 # Datasource configuration
 spring.datasource.url=jdbc:postgresql://${DB_HOST_EC2}:5432/clinicwave-user-management
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.username=${PROD_POSTGRES_USERNAME}
+spring.datasource.password=${PROD_POSTGRES_PASSWORD}
 
 # JPA database platform configuration
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,5 @@ spring.jpa.properties.hibernate.format_sql=true
 
 # ClinicWave User Management frontend application base URL
 clinicwave-user-management-frontend-base-url=http://localhost:5173
+
+spring.config.import=secrets.properties


### PR DESCRIPTION
### Description:
This pull request introduces changes to replace hardcoded credentials in the `application-prod.properties` and `application-docker.properties` files with environment variables. This enhances the security and flexibility of the application by preventing sensitive information from being exposed in the codebase.

### Changes:
- Added `.env` and `secrets.properties` to `.gitignore` to prevent these files from being tracked in version control.
- Updated `docker-compose.yml` to utilize environment variables for PostgreSQL credentials, replacing previously hardcoded values.
- Modified `application-docker.properties` to fetch PostgreSQL credentials from environment variables instead of hardcoding them.
- Updated `application-prod.properties` to use environment variables for PostgreSQL credentials, aligning with best security practices.
- Introduced `spring.config.import=secrets.properties` in `application.properties` to load secrets from a dedicated properties file.

### Purpose:
The purpose of this pull request is to enhance the security of the application by removing hardcoded credentials from the configuration files. By using environment variables and a separate secrets properties file, we can protect sensitive information and make the application more adaptable to different environments.

This PR fixes #74 
