### PR TITLE
Add Startup Script to Run Backend with Docker Profile

### DIFF
--- a/installer/start-backend.sh
+++ b/installer/start-backend.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Navigate to the parent directory where mvnw is located
+cd ../ || exit
+
+# Start only the database service using Docker
+echo "Starting the services..."
+docker compose up -d
+
+# Wait a few seconds to ensure the services is up
+sleep 10
+
+# Run the Spring Boot application locally
+echo "Running the Spring Boot backend in docker environment..."
+./mvnw spring-boot:run -Dspring-boot.run.profiles=docker
+
+# Provide feedback
+if [ $? -eq 0 ]; then
+    echo "Backend is running locally, and the services is running in Docker!"
+    echo "You can access the API at http://localhost:8080"
+else
+    echo "Failed to start the backend. Please check the logs."
+fi
+


### PR DESCRIPTION
### Description:
This pull request introduces a new startup script (`start-backend.sh`) that simplifies the process of running the backend service with Docker. It starts the necessary services (PostgreSQL, Zookeeper, Kafka) in Docker and runs the Spring Boot application locally using the Docker profile.

### Changes:
- Added a `start-backend.sh` script in the `installer` directory.
- Configured the script to navigate to the parent directory and start Docker services (database, Zookeeper, Kafka) in detached mode.
- Introduced a wait time to ensure services are running.
- Configured the Spring Boot application to run locally with the Docker profile.
- Provided feedback on successful or failed startup and API access details.

### Purpose:
The purpose of this pull request is to simplify the backend startup process for developers. By utilizing Docker to manage external services (PostgreSQL, Zookeeper, Kafka) and running the Spring Boot backend locally, this script streamlines the process, improving developer efficiency and ensuring consistent setup.

Solves issue #76.
