### PR TITLE
 Refactor Manual Constructor Dependency Injection to Use Lombok's @AllArgsConstructor

### DIFF
--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/client/impl/NotificationServiceClientImpl.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/client/impl/NotificationServiceClientImpl.java
@@ -2,8 +2,8 @@ package com.clinicwave.clinicwaveusermanagementservice.client.impl;
 
 import com.clinicwave.clinicwaveusermanagementservice.client.NotificationServiceClient;
 import com.clinicwave.clinicwaveusermanagementservice.dto.NotificationRequestDto;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -15,19 +15,10 @@ import org.springframework.web.client.RestTemplate;
  * @author aamir on 7/14/24
  */
 @Service
+@AllArgsConstructor
 @Slf4j
 public class NotificationServiceClientImpl implements NotificationServiceClient {
   private final RestTemplate restTemplate;
-
-  /**
-   * Constructor for dependency injection.
-   *
-   * @param restTemplate The RestTemplate to be used for sending HTTP requests.
-   */
-  @Autowired
-  public NotificationServiceClientImpl(RestTemplate restTemplate) {
-    this.restTemplate = restTemplate;
-  }
 
   /**
    * Sends a notification to the notification service.

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/controller/ClinicWaveUserController.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/controller/ClinicWaveUserController.java
@@ -3,7 +3,7 @@ package com.clinicwave.clinicwaveusermanagementservice.controller;
 import com.clinicwave.clinicwaveusermanagementservice.dto.ClinicWaveUserDto;
 import com.clinicwave.clinicwaveusermanagementservice.service.ClinicWaveUserService;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,18 +19,9 @@ import java.util.List;
  */
 @RestController
 @RequestMapping(value = "/api/users", produces = "application/json")
+@AllArgsConstructor
 public class ClinicWaveUserController {
   private final ClinicWaveUserService clinicWaveUserService;
-
-  /**
-   * Constructor for the ClinicWaveUserController class.
-   *
-   * @param clinicWaveUserService the ClinicWaveUserService to be used for handling business logic
-   */
-  @Autowired
-  public ClinicWaveUserController(ClinicWaveUserService clinicWaveUserService) {
-    this.clinicWaveUserService = clinicWaveUserService;
-  }
 
   /**
    * Retrieves a ClinicWaveUser entity by its ID and returns it as a response entity.

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/controller/ClinicWaveUserRoleAssignmentController.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/controller/ClinicWaveUserRoleAssignmentController.java
@@ -2,7 +2,7 @@ package com.clinicwave.clinicwaveusermanagementservice.controller;
 
 import com.clinicwave.clinicwaveusermanagementservice.dto.ClinicWaveUserRoleAssignmentDto;
 import com.clinicwave.clinicwaveusermanagementservice.service.ClinicWaveUserRoleAssignment;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,18 +14,9 @@ import org.springframework.web.bind.annotation.*;
  */
 @RestController
 @RequestMapping(value = "/api/users", produces = "application/json")
+@AllArgsConstructor
 public class ClinicWaveUserRoleAssignmentController {
   private final ClinicWaveUserRoleAssignment clinicWaveUserRoleAssignment;
-
-  /**
-   * Constructor for the ClinicWaveUserRoleAssignmentController class.
-   *
-   * @param clinicWaveUserRoleAssignment the ClinicWaveUserRoleAssignment to be used for handling business logic
-   */
-  @Autowired
-  public ClinicWaveUserRoleAssignmentController(ClinicWaveUserRoleAssignment clinicWaveUserRoleAssignment) {
-    this.clinicWaveUserRoleAssignment = clinicWaveUserRoleAssignment;
-  }
 
   /**
    * Provisions a role for a user.

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/controller/VerificationCodeController.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/controller/VerificationCodeController.java
@@ -4,8 +4,8 @@ import com.clinicwave.clinicwaveusermanagementservice.dto.VerificationRequestDto
 import com.clinicwave.clinicwaveusermanagementservice.dto.VerificationStatusDto;
 import com.clinicwave.clinicwaveusermanagementservice.service.VerificationCodeService;
 import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,19 +18,10 @@ import java.util.Map;
  */
 @RestController
 @RequestMapping("/api/verification")
+@AllArgsConstructor
 @Slf4j
 public class VerificationCodeController {
   private final VerificationCodeService verificationCodeService;
-
-  /**
-   * Constructs a new VerificationCodeController with the given VerificationCodeService.
-   *
-   * @param verificationCodeService the VerificationCodeService to be used for verification code operations
-   */
-  @Autowired
-  public VerificationCodeController(VerificationCodeService verificationCodeService) {
-    this.verificationCodeService = verificationCodeService;
-  }
 
   /**
    * Checks the verification status for the specified token.

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/initializer/RolePermissionUserTypeInitializer.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/initializer/RolePermissionUserTypeInitializer.java
@@ -12,8 +12,8 @@ import com.clinicwave.clinicwaveusermanagementservice.repository.PermissionRepos
 import com.clinicwave.clinicwaveusermanagementservice.repository.RoleRepository;
 import com.clinicwave.clinicwaveusermanagementservice.repository.UserTypeRepository;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
  * @author aamir on 6/30/24
  */
 @Component
+@RequiredArgsConstructor
 @Slf4j
 public class RolePermissionUserTypeInitializer implements CommandLineRunner {
   private static final String PERMISSION = "Permission";
@@ -38,20 +39,6 @@ public class RolePermissionUserTypeInitializer implements CommandLineRunner {
   private final RoleRepository roleRepository;
   private final UserTypeRepository userTypeRepository;
   private final PermissionRepository permissionRepository;
-
-  /**
-   * Constructor for the DatabaseInitializer class.
-   *
-   * @param roleRepository       the RoleRepository to be used for database operations
-   * @param userTypeRepository   the UserTypeRepository to be used for database operations
-   * @param permissionRepository the PermissionRepository to be used for database operations
-   */
-  @Autowired
-  public RolePermissionUserTypeInitializer(RoleRepository roleRepository, UserTypeRepository userTypeRepository, PermissionRepository permissionRepository) {
-    this.roleRepository = roleRepository;
-    this.userTypeRepository = userTypeRepository;
-    this.permissionRepository = permissionRepository;
-  }
 
   /**
    * This method initializes the database with default values.

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/RoleMapper.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/mapper/RoleMapper.java
@@ -4,7 +4,7 @@ import com.clinicwave.clinicwaveusermanagementservice.domain.Role;
 import com.clinicwave.clinicwaveusermanagementservice.domain.RolePermission;
 import com.clinicwave.clinicwaveusermanagementservice.dto.PermissionDto;
 import com.clinicwave.clinicwaveusermanagementservice.dto.RoleDto;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -19,19 +19,9 @@ import java.util.stream.Collectors;
  * @author aamir on 6/16/24
  */
 @Component
+@AllArgsConstructor
 public class RoleMapper {
   private final PermissionMapper permissionMapper;
-
-  /**
-   * Constructor for the PermissionMapper class.
-   * It initializes the permissionMapper with the provided mapper.
-   *
-   * @param permissionMapper the PermissionMapper to be used for mapping Permission objects
-   */
-  @Autowired
-  public RoleMapper(PermissionMapper permissionMapper) {
-    this.permissionMapper = permissionMapper;
-  }
 
   /**
    * Converts a Role domain object into a RoleDto data transfer object.

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserRoleAssignmentImpl.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserRoleAssignmentImpl.java
@@ -10,7 +10,7 @@ import com.clinicwave.clinicwaveusermanagementservice.repository.ClinicWaveUserR
 import com.clinicwave.clinicwaveusermanagementservice.repository.RoleRepository;
 import com.clinicwave.clinicwaveusermanagementservice.service.ClinicWaveUserRoleAssignment;
 import jakarta.transaction.Transactional;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -24,21 +24,10 @@ import java.util.Objects;
  * @author aamir on 6/30/24
  */
 @Service
+@AllArgsConstructor
 public class ClinicWaveUserRoleAssignmentImpl implements ClinicWaveUserRoleAssignment {
   private final ClinicWaveUserRepository clinicWaveUserRepository;
   private final RoleRepository roleRepository;
-
-  /**
-   * Constructor for the ClinicWaveUserRoleAssignmentImpl class.
-   *
-   * @param clinicWaveUserRepository the ClinicWaveUserRepository to be used for database operations
-   * @param roleRepository           the RoleRepository to be used for database operations
-   */
-  @Autowired
-  public ClinicWaveUserRoleAssignmentImpl(ClinicWaveUserRepository clinicWaveUserRepository, RoleRepository roleRepository) {
-    this.clinicWaveUserRepository = clinicWaveUserRepository;
-    this.roleRepository = roleRepository;
-  }
 
   /**
    * Assigns a role to a ClinicWaveUser entity.

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserServiceImpl.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/ClinicWaveUserServiceImpl.java
@@ -16,8 +16,8 @@ import com.clinicwave.clinicwaveusermanagementservice.service.ClinicWaveUserServ
 import com.clinicwave.clinicwaveusermanagementservice.service.VerificationCodeService;
 import com.clinicwave.clinicwaveusermanagementservice.util.NotificationUtil;
 import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
@@ -34,6 +34,7 @@ import java.util.Map;
  * @author aamir on 6/13/24
  */
 @Service
+@AllArgsConstructor
 @Slf4j
 public class ClinicWaveUserServiceImpl implements ClinicWaveUserService {
   private final ClinicWaveUserRepository clinicWaveUserRepository;
@@ -46,26 +47,6 @@ public class ClinicWaveUserServiceImpl implements ClinicWaveUserService {
   @Value("${clinicwave-user-management-frontend-base-url}")
   private String clinicwaveUserManagementFrontendBaseUrl;
   private static final String TOPIC_NAME = "notification-topic";
-
-  /**
-   * Constructor for the ClinicWaveUserServiceImpl class.
-   *
-   * @param clinicWaveUserRepository the ClinicWaveUserRepository to be used for database operations
-   * @param roleRepository           the RoleRepository to be used for database operations
-   * @param userTypeRepository       the UserTypeRepository to be used for database operations
-   * @param clinicWaveUserMapper     the ClinicWaveUserMapper to be used for object mapping
-   * @param verificationCodeService  the VerificationCodeService to be used for generating verification codes
-   * @param kafkaTemplate            the KafkaTemplate to be used for sending notifications
-   */
-  @Autowired
-  public ClinicWaveUserServiceImpl(ClinicWaveUserRepository clinicWaveUserRepository, RoleRepository roleRepository, UserTypeRepository userTypeRepository, ClinicWaveUserMapper clinicWaveUserMapper, VerificationCodeService verificationCodeService, KafkaTemplate<String, NotificationRequestDto> kafkaTemplate) {
-    this.clinicWaveUserRepository = clinicWaveUserRepository;
-    this.roleRepository = roleRepository;
-    this.userTypeRepository = userTypeRepository;
-    this.clinicWaveUserMapper = clinicWaveUserMapper;
-    this.verificationCodeService = verificationCodeService;
-    this.kafkaTemplate = kafkaTemplate;
-  }
 
   /**
    * Retrieves a ClinicWaveUser entity by its ID and converts it into a ClinicWaveUserDto data transfer object.

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/VerificationCodeServiceImpl.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/service/impl/VerificationCodeServiceImpl.java
@@ -13,8 +13,8 @@ import com.clinicwave.clinicwaveusermanagementservice.exception.VerificationCode
 import com.clinicwave.clinicwaveusermanagementservice.repository.ClinicWaveUserRepository;
 import com.clinicwave.clinicwaveusermanagementservice.repository.VerificationCodeRepository;
 import com.clinicwave.clinicwaveusermanagementservice.service.VerificationCodeService;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
@@ -29,6 +29,7 @@ import java.util.UUID;
  * @author aamir on 7/7/24
  */
 @Service
+@AllArgsConstructor
 @Slf4j
 public class VerificationCodeServiceImpl implements VerificationCodeService {
   private static final String VERIFICATION_CODE = "VerificationCode";
@@ -40,18 +41,6 @@ public class VerificationCodeServiceImpl implements VerificationCodeService {
 
   private final VerificationCodeRepository verificationCodeRepository;
   private final ClinicWaveUserRepository clinicWaveUserRepository;
-
-  /**
-   * Constructs a new VerificationCodeServiceImpl with the given VerificationCodeRepository.
-   *
-   * @param verificationCodeRepository the VerificationCodeRepository to be used for database operations
-   * @param clinicWaveUserRepository   the ClinicWaveUserRepository to be used for database operations
-   */
-  @Autowired
-  public VerificationCodeServiceImpl(VerificationCodeRepository verificationCodeRepository, ClinicWaveUserRepository clinicWaveUserRepository) {
-    this.verificationCodeRepository = verificationCodeRepository;
-    this.clinicWaveUserRepository = clinicWaveUserRepository;
-  }
 
   /**
    * Generates a verification code for the specified user and verification code type.

--- a/src/main/java/com/clinicwave/clinicwaveusermanagementservice/validator/UniqueFieldValidator.java
+++ b/src/main/java/com/clinicwave/clinicwaveusermanagementservice/validator/UniqueFieldValidator.java
@@ -4,30 +4,19 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.AllArgsConstructor;
 
 /**
  * This class implements the ConstraintValidator interface and defines the logic to validate a constraint of type UniqueField.
  * It uses the EntityManager to query the database and check if a given value is unique for a specified field in a specified domain class.
- * The class is annotated with @Autowired to allow Spring to handle the lifecycle of the EntityManager.
  *
  * @author aamir on 6/18/24
  */
+@AllArgsConstructor
 public class UniqueFieldValidator implements ConstraintValidator<UniqueField, Object> {
   private final EntityManager entityManager;
   private String fieldName;
   private Class<?> domainClass;
-
-  /**
-   * Constructor for the UniqueFieldValidator class.
-   * It initializes the entityManager with the provided EntityManager.
-   *
-   * @param entityManager the EntityManager to be used for database queries
-   */
-  @Autowired
-  public UniqueFieldValidator(EntityManager entityManager) {
-    this.entityManager = entityManager;
-  }
 
   /**
    * Initializes the validator with the constraint annotation instance.

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/config/KafkaProducerConfigTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/config/KafkaProducerConfigTest.java
@@ -1,11 +1,11 @@
 package com.clinicwave.clinicwaveusermanagementservice.config;
 
 import com.clinicwave.clinicwaveusermanagementservice.dto.NotificationRequestDto;
+import lombok.AllArgsConstructor;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author aamir on 8/25/24
  */
 @SpringBootTest
+@AllArgsConstructor
 class KafkaProducerConfigTest {
   @Value("${spring.kafka.bootstrap-servers}")
   private String bootstrapServers;
@@ -33,18 +34,6 @@ class KafkaProducerConfigTest {
 
   @MockBean
   private KafkaTemplate<String, NotificationRequestDto> kafkaTemplate;
-
-  /**
-   * Constructor for dependency injection.
-   *
-   * @param kafkaProducerConfig The KafkaProducerConfig object to be tested
-   * @param producerFactory     The ProducerFactory object to be tested
-   */
-  @Autowired
-  public KafkaProducerConfigTest(KafkaProducerConfig kafkaProducerConfig, ProducerFactory<String, NotificationRequestDto> producerFactory) {
-    this.kafkaProducerConfig = kafkaProducerConfig;
-    this.producerFactory = producerFactory;
-  }
 
   @Test
   @DisplayName("Test KafkaProducerConfig bean")

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/controller/ClinicWaveUserControllerTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/controller/ClinicWaveUserControllerTest.java
@@ -4,10 +4,10 @@ import com.clinicwave.clinicwaveusermanagementservice.dto.ClinicWaveUserDto;
 import com.clinicwave.clinicwaveusermanagementservice.enums.GenderEnum;
 import com.clinicwave.clinicwaveusermanagementservice.service.ClinicWaveUserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -35,6 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author aamir on 6/13/24
  */
 @SpringBootTest
+@AllArgsConstructor
 @AutoConfigureMockMvc
 class ClinicWaveUserControllerTest {
   private final MockMvc mockMvc;
@@ -45,18 +46,6 @@ class ClinicWaveUserControllerTest {
   private ClinicWaveUserService clinicWaveUserService;
 
   private ClinicWaveUserDto createdClinicWaveUserDto;
-
-  /**
-   * Constructs a new ClinicWaveUserControllerTest with the given MockMvc and ObjectMapper.
-   *
-   * @param mockMvc      the MockMvc instance to use for testing
-   * @param objectMapper the ObjectMapper instance to use for JSON serialization and deserialization
-   */
-  @Autowired
-  public ClinicWaveUserControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
-    this.mockMvc = mockMvc;
-    this.objectMapper = objectMapper;
-  }
 
   /**
    * Sets up the test environment by creating a new ClinicWaveUserDto instance.

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/controller/ClinicWaveUserRoleAssignmentControllerTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/controller/ClinicWaveUserRoleAssignmentControllerTest.java
@@ -7,9 +7,9 @@ import com.clinicwave.clinicwaveusermanagementservice.exception.DuplicateRoleAss
 import com.clinicwave.clinicwaveusermanagementservice.exception.ResourceNotFoundException;
 import com.clinicwave.clinicwaveusermanagementservice.exception.RoleMismatchException;
 import com.clinicwave.clinicwaveusermanagementservice.service.ClinicWaveUserRoleAssignment;
+import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -32,21 +32,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @SpringBootTest
 @AutoConfigureMockMvc
+@AllArgsConstructor
 class ClinicWaveUserRoleAssignmentControllerTest {
   private final MockMvc mockMvc;
 
   @MockBean
   private ClinicWaveUserRoleAssignment clinicWaveUserRoleAssignment;
-
-  /**
-   * Constructs a new ClinicWaveUserRoleAssignmentControllerTest with the given MockMvc and ObjectMapper.
-   *
-   * @param mockMvc the MockMvc instance to use for testing
-   */
-  @Autowired
-  public ClinicWaveUserRoleAssignmentControllerTest(MockMvc mockMvc) {
-    this.mockMvc = mockMvc;
-  }
 
   @Test
   @DisplayName("POST /api/users/{userId}/roles/{roleId}")

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/controller/VerificationCodeControllerTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/controller/VerificationCodeControllerTest.java
@@ -8,10 +8,10 @@ import com.clinicwave.clinicwaveusermanagementservice.exception.VerificationCode
 import com.clinicwave.clinicwaveusermanagementservice.exception.VerificationCodeExpiredException;
 import com.clinicwave.clinicwaveusermanagementservice.service.VerificationCodeService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -31,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @SpringBootTest
 @AutoConfigureMockMvc
+@AllArgsConstructor
 class VerificationCodeControllerTest {
   private final MockMvc mockMvc;
 
@@ -46,18 +47,6 @@ class VerificationCodeControllerTest {
   private static final String URL_TEMPLATE = "/api/verification/verify";
   public static final String EMAIL = "test@example.com";
   private static final String TOKEN = "91cd894d-7c2b-41d8-92cf-7ecb17b931ea";
-
-  /**
-   * Constructs a new VerificationCodeControllerTest with the given MockMvc and ObjectMapper.
-   *
-   * @param mockMvc      the MockMvc instance to use for testing
-   * @param objectMapper the ObjectMapper instance to use for JSON serialization and deserialization
-   */
-  @Autowired
-  public VerificationCodeControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
-    this.mockMvc = mockMvc;
-    this.objectMapper = objectMapper;
-  }
 
   /**
    * Sets up the test environment before each test.

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/controller/integration/ClinicWaveUserControllerIntegrationTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/controller/integration/ClinicWaveUserControllerIntegrationTest.java
@@ -5,10 +5,10 @@ import com.clinicwave.clinicwaveusermanagementservice.dto.ClinicWaveUserDto;
 import com.clinicwave.clinicwaveusermanagementservice.dto.NotificationRequestDto;
 import com.clinicwave.clinicwaveusermanagementservice.enums.GenderEnum;
 import com.clinicwave.clinicwaveusermanagementservice.repository.ClinicWaveUserRepository;
+import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -26,7 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
 
 /**
  * This class provides integration tests for the ClinicWaveUserController class.
@@ -40,6 +41,7 @@ import static org.mockito.Mockito.*;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(KafkaTemplateMockConfig.class)
 @AutoConfigureTestDatabase
+@AllArgsConstructor
 class ClinicWaveUserControllerIntegrationTest {
   private final TestRestTemplate restTemplate;
 
@@ -49,20 +51,6 @@ class ClinicWaveUserControllerIntegrationTest {
 
   private ClinicWaveUserDto createdClinicWaveUserDto;
   private ClinicWaveUserDto createdClinicWaveUserDto2;
-
-  /**
-   * Constructs a new ClinicWaveUserControllerIntegrationTest with the given TestRestTemplate and ClinicWaveUserRepository.
-   *
-   * @param restTemplate             the TestRestTemplate instance to use for testing
-   * @param clinicWaveUserRepository the ClinicWaveUserRepository instance to use for testing
-   * @param kafkaTemplate            the KafkaTemplate instance to use for testing
-   */
-  @Autowired
-  public ClinicWaveUserControllerIntegrationTest(TestRestTemplate restTemplate, ClinicWaveUserRepository clinicWaveUserRepository, KafkaTemplate<String, NotificationRequestDto> kafkaTemplate) {
-    this.restTemplate = restTemplate;
-    this.clinicWaveUserRepository = clinicWaveUserRepository;
-    this.kafkaTemplate = kafkaTemplate;
-  }
 
   /**
    * Sets up the test environment before each test.

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/controller/integration/testcontainers/ClinicWaveUserControllerTestContainersIntegrationTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/controller/integration/testcontainers/ClinicWaveUserControllerTestContainersIntegrationTest.java
@@ -5,10 +5,10 @@ import com.clinicwave.clinicwaveusermanagementservice.dto.ClinicWaveUserDto;
 import com.clinicwave.clinicwaveusermanagementservice.dto.NotificationRequestDto;
 import com.clinicwave.clinicwaveusermanagementservice.enums.GenderEnum;
 import com.clinicwave.clinicwaveusermanagementservice.repository.ClinicWaveUserRepository;
+import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.annotation.Import;
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.verify;
 @ActiveProfiles("docker")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(KafkaTemplateMockConfig.class)
+@AllArgsConstructor
 @Testcontainers
 class ClinicWaveUserControllerTestContainersIntegrationTest {
   // Define a PostgreSQL container for the test
@@ -80,19 +81,6 @@ class ClinicWaveUserControllerTestContainersIntegrationTest {
     registry.add("spring.datasource.username", postgreSQLContainer::getUsername);
     registry.add("spring.datasource.password", postgreSQLContainer::getPassword);
     registry.add("spring.kafka.bootstrap-servers", kafkaContainer::getBootstrapServers);
-  }
-
-  /**
-   * Constructs a new ClinicWaveUserControllerTestContainersIntegrationTest with the given TestRestTemplate and ClinicWaveUserRepository.
-   *
-   * @param restTemplate             the TestRestTemplate instance to use for testing
-   * @param clinicWaveUserRepository the ClinicWaveUserRepository instance to use for testing
-   */
-  @Autowired
-  public ClinicWaveUserControllerTestContainersIntegrationTest(TestRestTemplate restTemplate, ClinicWaveUserRepository clinicWaveUserRepository, KafkaTemplate<String, NotificationRequestDto> kafkaTemplate) {
-    this.restTemplate = restTemplate;
-    this.clinicWaveUserRepository = clinicWaveUserRepository;
-    this.kafkaTemplate = kafkaTemplate;
   }
 
   /**

--- a/src/test/java/com/clinicwave/clinicwaveusermanagementservice/mapper/ClinicWaveUserMapperTest.java
+++ b/src/test/java/com/clinicwave/clinicwaveusermanagementservice/mapper/ClinicWaveUserMapperTest.java
@@ -3,10 +3,10 @@ package com.clinicwave.clinicwaveusermanagementservice.mapper;
 import com.clinicwave.clinicwaveusermanagementservice.domain.ClinicWaveUser;
 import com.clinicwave.clinicwaveusermanagementservice.dto.ClinicWaveUserDto;
 import com.clinicwave.clinicwaveusermanagementservice.enums.GenderEnum;
+import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
@@ -20,21 +20,12 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author aamir on 6/19/24
  */
 @SpringBootTest
+@AllArgsConstructor
 class ClinicWaveUserMapperTest {
   private final ClinicWaveUserMapper clinicWaveUserMapper;
 
   private ClinicWaveUser clinicWaveUser;
   private ClinicWaveUserDto clinicWaveUserDto;
-
-  /**
-   * Constructor for the test class, initializes the mapper.
-   *
-   * @param clinicWaveUserMapper the mapper to be tested
-   */
-  @Autowired
-  public ClinicWaveUserMapperTest(ClinicWaveUserMapper clinicWaveUserMapper) {
-    this.clinicWaveUserMapper = clinicWaveUserMapper;
-  }
 
   /**
    * Sets up the test data before each test.


### PR DESCRIPTION
### Description:
This pull request introduces the replacement of manual constructor dependency injection with Lombok's `@AllArgsConstructor` to improve code readability and reduce boilerplate.

### Changes:
- Added `@AllArgsConstructor` annotation to relevant classes
- Removed explicit constructor definitions where applicable
- Improved maintainability by leveraging Lombok for dependency injection

### Purpose:
The purpose of this pull request is to enhance code maintainability and readability by eliminating redundant constructor definitions. By using Lombok's `@AllArgsConstructor`, we reduce boilerplate code while ensuring that dependencies are injected properly, leading to cleaner and more efficient code.

This PR solves #93.
